### PR TITLE
feat: scaffold backend with NestJS and Prisma

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,11 @@ jobs:
 
       - name: Typecheck (root)
         run: pnpm run typecheck:root
+
+      - name: Lint (backend)
+        if: ${{ hashFiles('apps/backend/package.json') != '' }}
+        run: pnpm -w -F @sed-shop/backend lint
+
+      - name: Typecheck (backend)
+        if: ${{ hashFiles('apps/backend/package.json') != '' }}
+        run: pnpm -w -F @sed-shop/backend typecheck

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,0 +1,6 @@
+PORT=3000
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/sedshop?schema=public"
+REDIS_URL="redis://localhost:6379"
+JWT_SECRET="changeme"
+JWT_ACCESS_TTL=600
+JWT_REFRESH_TTL=1209600

--- a/apps/backend/jest.config.ts
+++ b/apps/backend/jest.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    // eslint-disable-next-line no-useless-escape
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  testMatch: ['<rootDir>/test/**/*.e2e-spec.ts'],
+};
+
+export default config;

--- a/apps/backend/nest-cli.json
+++ b/apps/backend/nest-cli.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "tsConfigPath": "tsconfig.build.json"
+  }
+}

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@sed-shop/backend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nest start --watch",
+    "build": "nest build",
+    "start:prod": "node dist/main.js",
+    "lint": "eslint src --ext .ts --max-warnings=0",
+    "typecheck": "tsc -p tsconfig.build.json --noEmit && tsc -p tsconfig.prisma.json --noEmit",
+    "test": "jest",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate deploy",
+    "prisma:seed": "tsx prisma/seed.ts"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.3.0",
+    "@nestjs/core": "^10.3.0",
+    "@nestjs/platform-express": "^10.3.0",
+    "@nestjs/swagger": "^7.3.0",
+    "nestjs-pino": "^3.4.0",
+    "pino": "^9.0.0",
+    "helmet": "^7.0.0",
+    "prom-client": "^15.1.0",
+    "uuid": "^9.0.0",
+    "@prisma/client": "^5.17.0"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.3.0",
+    "@nestjs/testing": "^10.3.0",
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.11",
+    "@types/node": "^20.5.0",
+    "@types/supertest": "^2.0.12",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.2",
+    "tsx": "^4.16.0",
+    "typescript": "^5.5.4",
+    "prisma": "^5.17.0"
+  }
+}

--- a/apps/backend/prisma/migrations/000_init/migration.sql
+++ b/apps/backend/prisma/migrations/000_init/migration.sql
@@ -1,0 +1,262 @@
+-- Create enums
+CREATE TYPE "UserRole" AS ENUM ('CUSTOMER', 'STAFF', 'ADMIN');
+CREATE TYPE "OrderStatus" AS ENUM ('PENDING', 'PAID', 'FULFILLED', 'CANCELLED', 'REFUNDED');
+CREATE TYPE "PaymentStatus" AS ENUM ('PENDING', 'AUTHORIZED', 'CAPTURED', 'FAILED', 'REFUNDED');
+CREATE TYPE "ShipmentStatus" AS ENUM ('PENDING', 'PACKED', 'SHIPPED', 'DELIVERED', 'RETURNED');
+
+-- Create tables
+CREATE TABLE "User" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "email" TEXT NOT NULL,
+  "passwordHash" TEXT NOT NULL,
+  "fullName" TEXT,
+  "role" "UserRole" NOT NULL DEFAULT 'CUSTOMER',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deleted_at" TIMESTAMP(3),
+  CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "Address" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "userId" UUID NOT NULL,
+  "fullName" TEXT NOT NULL,
+  "phone" TEXT NOT NULL,
+  "line1" TEXT NOT NULL,
+  "line2" TEXT,
+  "city" TEXT NOT NULL,
+  "state" TEXT,
+  "postalCode" TEXT,
+  "country" TEXT NOT NULL DEFAULT 'IR',
+  "isDefault" BOOLEAN NOT NULL DEFAULT false,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deleted_at" TIMESTAMP(3),
+  CONSTRAINT "Address_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "Category" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "name" TEXT NOT NULL,
+  "slug" TEXT NOT NULL,
+  "description" TEXT,
+  "parentId" UUID,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deleted_at" TIMESTAMP(3),
+  CONSTRAINT "Category_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "Product" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "title" TEXT NOT NULL,
+  "slug" TEXT NOT NULL,
+  "description" TEXT,
+  "categoryId" UUID,
+  "published" BOOLEAN NOT NULL DEFAULT true,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deleted_at" TIMESTAMP(3),
+  CONSTRAINT "Product_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "ProductVariant" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "productId" UUID NOT NULL,
+  "sku" TEXT NOT NULL,
+  "title" TEXT,
+  "price" DECIMAL(12,0) NOT NULL,
+  "compareAtPrice" DECIMAL(12,0),
+  "stock" INTEGER NOT NULL DEFAULT 0,
+  "attributes" JSONB,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deleted_at" TIMESTAMP(3),
+  CONSTRAINT "ProductVariant_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "Image" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "productId" UUID NOT NULL,
+  "url" TEXT NOT NULL,
+  "alt" TEXT,
+  "position" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deleted_at" TIMESTAMP(3),
+  CONSTRAINT "Image_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "Coupon" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "code" TEXT NOT NULL,
+  "isPercent" BOOLEAN NOT NULL DEFAULT true,
+  "value" DECIMAL(12,0) NOT NULL,
+  "minOrderAmount" DECIMAL(12,0),
+  "startsAt" TIMESTAMP(3),
+  "endsAt" TIMESTAMP(3),
+  "usageLimit" INTEGER,
+  "usedCount" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deleted_at" TIMESTAMP(3),
+  CONSTRAINT "Coupon_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "Cart" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "userId" UUID,
+  "sessionId" TEXT,
+  "status" TEXT NOT NULL DEFAULT 'ACTIVE',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deleted_at" TIMESTAMP(3),
+  CONSTRAINT "Cart_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "CartItem" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "cartId" UUID NOT NULL,
+  "productId" UUID NOT NULL,
+  "variantId" UUID NOT NULL,
+  "quantity" INTEGER NOT NULL DEFAULT 1,
+  "price_snapshot" DECIMAL(12,0) NOT NULL,
+  "currency" TEXT NOT NULL DEFAULT 'IRR',
+  "productTitle_snapshot" TEXT NOT NULL,
+  "variantTitle_snapshot" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deleted_at" TIMESTAMP(3),
+  CONSTRAINT "CartItem_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "Order" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "userId" UUID,
+  "status" "OrderStatus" NOT NULL DEFAULT 'PENDING',
+  "couponId" UUID,
+  "shipping_fullName" TEXT,
+  "shipping_phone" TEXT,
+  "shipping_line1" TEXT,
+  "shipping_line2" TEXT,
+  "shipping_city" TEXT,
+  "shipping_state" TEXT,
+  "shipping_postalCode" TEXT,
+  "shipping_country" TEXT DEFAULT 'IR',
+  "totalAmount" DECIMAL(12,0) NOT NULL,
+  "currency" TEXT NOT NULL DEFAULT 'IRR',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deleted_at" TIMESTAMP(3),
+  CONSTRAINT "Order_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "OrderItem" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "orderId" UUID NOT NULL,
+  "productId" UUID NOT NULL,
+  "variantId" UUID NOT NULL,
+  "quantity" INTEGER NOT NULL DEFAULT 1,
+  "price_snapshot" DECIMAL(12,0) NOT NULL,
+  "currency" TEXT NOT NULL DEFAULT 'IRR',
+  "productTitle_snapshot" TEXT NOT NULL,
+  "variantTitle_snapshot" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deleted_at" TIMESTAMP(3),
+  CONSTRAINT "OrderItem_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "Payment" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "orderId" UUID NOT NULL,
+  "provider" TEXT NOT NULL DEFAULT 'mock',
+  "amount" DECIMAL(12,0) NOT NULL,
+  "currency" TEXT NOT NULL DEFAULT 'IRR',
+  "status" "PaymentStatus" NOT NULL DEFAULT 'PENDING',
+  "transactionId" TEXT,
+  "idempotencyKey" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deleted_at" TIMESTAMP(3),
+  CONSTRAINT "Payment_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "Shipment" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "orderId" UUID NOT NULL,
+  "carrier" TEXT NOT NULL DEFAULT 'mock',
+  "trackingNumber" TEXT,
+  "status" "ShipmentStatus" NOT NULL DEFAULT 'PENDING',
+  "cost" DECIMAL(12,0),
+  "shippedAt" TIMESTAMP(3),
+  "deliveredAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deleted_at" TIMESTAMP(3),
+  CONSTRAINT "Shipment_pkey" PRIMARY KEY ("id")
+);
+
+-- Create indexes and constraints
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE INDEX "User_role_idx" ON "User"("role");
+
+CREATE INDEX "Address_userId_idx" ON "Address"("userId");
+
+CREATE UNIQUE INDEX "Category_slug_key" ON "Category"("slug");
+
+CREATE UNIQUE INDEX "Product_slug_key" ON "Product"("slug");
+CREATE INDEX "Product_categoryId_idx" ON "Product"("categoryId");
+CREATE INDEX "Product_title_idx" ON "Product"("title");
+
+CREATE UNIQUE INDEX "ProductVariant_sku_key" ON "ProductVariant"("sku");
+CREATE INDEX "ProductVariant_productId_idx" ON "ProductVariant"("productId");
+
+CREATE INDEX "Image_productId_idx" ON "Image"("productId");
+
+CREATE UNIQUE INDEX "Coupon_code_key" ON "Coupon"("code");
+
+CREATE UNIQUE INDEX "Cart_sessionId_key" ON "Cart"("sessionId");
+
+CREATE INDEX "CartItem_cartId_idx" ON "CartItem"("cartId");
+CREATE INDEX "CartItem_productId_idx" ON "CartItem"("productId");
+CREATE INDEX "CartItem_variantId_idx" ON "CartItem"("variantId");
+
+CREATE INDEX "Order_userId_idx" ON "Order"("userId");
+CREATE INDEX "Order_status_idx" ON "Order"("status");
+
+CREATE INDEX "OrderItem_orderId_idx" ON "OrderItem"("orderId");
+
+CREATE INDEX "Payment_orderId_idx" ON "Payment"("orderId");
+CREATE INDEX "Payment_status_idx" ON "Payment"("status");
+
+CREATE INDEX "Shipment_orderId_idx" ON "Shipment"("orderId");
+CREATE INDEX "Shipment_status_idx" ON "Shipment"("status");
+
+-- Add foreign keys
+ALTER TABLE "Address" ADD CONSTRAINT "Address_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Category" ADD CONSTRAINT "Category_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Category"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "Product" ADD CONSTRAINT "Product_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "ProductVariant" ADD CONSTRAINT "ProductVariant_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Image" ADD CONSTRAINT "Image_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Cart" ADD CONSTRAINT "Cart_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "CartItem" ADD CONSTRAINT "CartItem_cartId_fkey" FOREIGN KEY ("cartId") REFERENCES "Cart"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "CartItem" ADD CONSTRAINT "CartItem_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "CartItem" ADD CONSTRAINT "CartItem_variantId_fkey" FOREIGN KEY ("variantId") REFERENCES "ProductVariant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "Order" ADD CONSTRAINT "Order_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Order" ADD CONSTRAINT "Order_couponId_fkey" FOREIGN KEY ("couponId") REFERENCES "Coupon"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "Order"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_variantId_fkey" FOREIGN KEY ("variantId") REFERENCES "ProductVariant"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "Payment" ADD CONSTRAINT "Payment_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "Order"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "Shipment" ADD CONSTRAINT "Shipment_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "Order"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/migrations/migration_lock.toml
+++ b/apps/backend/prisma/migrations/migration_lock.toml
@@ -1,0 +1,3 @@
+# Prisma Migrate Lockfile
+
+provider = "postgresql"

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1,0 +1,294 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum UserRole {
+  CUSTOMER
+  STAFF
+  ADMIN
+}
+
+enum OrderStatus {
+  PENDING
+  PAID
+  FULFILLED
+  CANCELLED
+  REFUNDED
+}
+
+enum PaymentStatus {
+  PENDING
+  AUTHORIZED
+  CAPTURED
+  FAILED
+  REFUNDED
+}
+
+enum ShipmentStatus {
+  PENDING
+  PACKED
+  SHIPPED
+  DELIVERED
+  RETURNED
+}
+
+model User {
+  id           String     @id @default(uuid())
+  email        String     @unique
+  passwordHash String
+  fullName     String?
+  role         UserRole   @default(CUSTOMER)
+
+  addresses    Address[]
+  carts        Cart[]
+  orders       Order[]
+
+  createdAt    DateTime   @default(now())
+  updatedAt    DateTime   @updatedAt
+  deleted_at   DateTime?
+
+  @@index([role])
+}
+
+model Address {
+  id          String   @id @default(uuid())
+  userId      String
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  fullName    String
+  phone       String
+  line1       String
+  line2       String?
+  city        String
+  state       String?
+  postalCode  String?
+  country     String    @default("IR")
+  isDefault   Boolean   @default(false)
+
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  deleted_at  DateTime?
+
+  @@index([userId])
+}
+
+model Category {
+  id          String     @id @default(uuid())
+  name        String
+  slug        String     @unique
+  description String?
+  parentId    String?
+  parent      Category?  @relation("CategoryToCategory", fields: [parentId], references: [id])
+  children    Category[] @relation("CategoryToCategory")
+  products    Product[]
+
+  createdAt   DateTime   @default(now())
+  updatedAt   DateTime   @updatedAt
+  deleted_at  DateTime?
+
+  @@index([slug])
+}
+
+model Product {
+  id           String           @id @default(uuid())
+  title        String
+  slug         String           @unique
+  description  String?
+  categoryId   String?
+  category     Category?        @relation(fields: [categoryId], references: [id])
+  published    Boolean          @default(true)
+
+  variants     ProductVariant[]
+  images       Image[]
+
+  createdAt    DateTime         @default(now())
+  updatedAt    DateTime         @updatedAt
+  deleted_at   DateTime?
+
+  @@index([categoryId])
+  @@index([title])
+}
+
+model ProductVariant {
+  id              String   @id @default(uuid())
+  productId       String
+  product         Product  @relation(fields: [productId], references: [id], onDelete: Cascade)
+  sku             String   @unique
+  title           String?
+  price           Decimal  @db.Decimal(12,0) // IRR (Rial)
+  compareAtPrice  Decimal? @db.Decimal(12,0) // IRR (Rial)
+  stock           Int      @default(0)
+  attributes      Json?
+
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  deleted_at      DateTime?
+
+  @@index([productId])
+}
+
+model Image {
+  id        String   @id @default(uuid())
+  productId String
+  product   Product  @relation(fields: [productId], references: [id], onDelete: Cascade)
+  url       String
+  alt       String?
+  position  Int      @default(0)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  deleted_at DateTime?
+
+  @@index([productId])
+}
+
+model Coupon {
+  id             String   @id @default(uuid())
+  code           String   @unique
+  // isPercent: true ⇒ value is 0..100 (percent as integer)
+  // isPercent: false ⇒ value is a fixed amount in IRR (Rial)
+  isPercent      Boolean  @default(true)
+  value          Decimal  @db.Decimal(12,0)
+  minOrderAmount Decimal? @db.Decimal(12,0) // IRR (Rial)
+  startsAt       DateTime?
+  endsAt         DateTime?
+  usageLimit     Int?
+  usedCount      Int      @default(0)
+
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+  deleted_at     DateTime?
+}
+
+model Cart {
+  id          String      @id @default(uuid())
+  userId      String?
+  user        User?       @relation(fields: [userId], references: [id])
+  sessionId   String?     @unique // for guest carts
+  status      String      @default("ACTIVE") // ACTIVE | ORDERED | ABANDONED
+
+  items       CartItem[]
+
+  createdAt   DateTime    @default(now())
+  updatedAt   DateTime    @updatedAt
+  deleted_at  DateTime?
+}
+
+model CartItem {
+  id              String   @id @default(uuid())
+  cartId          String
+  cart            Cart     @relation(fields: [cartId], references: [id], onDelete: Cascade)
+  productId       String
+  product         Product  @relation(fields: [productId], references: [id])
+  variantId       String
+  variant         ProductVariant @relation(fields: [variantId], references: [id])
+  quantity        Int      @default(1)
+  price_snapshot  Decimal  @db.Decimal(12,0) // IRR (Rial)
+  currency        String   @default("IRR")
+  productTitle_snapshot String
+  variantTitle_snapshot String?
+
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  deleted_at      DateTime?
+
+  @@index([cartId])
+  @@index([productId])
+  @@index([variantId])
+}
+
+model Order {
+  id           String        @id @default(uuid())
+  userId       String?
+  user         User?         @relation(fields: [userId], references: [id])
+  status       OrderStatus   @default(PENDING)
+  couponId     String?
+  coupon       Coupon?       @relation(fields: [couponId], references: [id])
+
+  // address snapshot
+  shipping_fullName   String?
+  shipping_phone      String?
+  shipping_line1      String?
+  shipping_line2      String?
+  shipping_city       String?
+  shipping_state      String?
+  shipping_postalCode String?
+  shipping_country    String? @default("IR")
+
+  totalAmount   Decimal       @db.Decimal(12,0) // IRR (Rial)
+  currency      String        @default("IRR")
+
+  items         OrderItem[]
+  payments      Payment[]
+  shipments     Shipment[]
+
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
+  deleted_at    DateTime?
+
+  @@index([userId])
+  @@index([status])
+}
+
+model OrderItem {
+  id              String   @id @default(uuid())
+  orderId         String
+  order           Order    @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  productId       String
+  product         Product  @relation(fields: [productId], references: [id])
+  variantId       String
+  variant         ProductVariant @relation(fields: [variantId], references: [id])
+  quantity        Int      @default(1)
+  price_snapshot  Decimal  @db.Decimal(12,0) // IRR (Rial)
+  currency        String   @default("IRR")
+  productTitle_snapshot String
+  variantTitle_snapshot String?
+
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+  deleted_at      DateTime?
+
+  @@index([orderId])
+}
+
+model Payment {
+  id              String        @id @default(uuid())
+  orderId         String
+  order           Order         @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  provider        String        @default("mock")
+  amount          Decimal       @db.Decimal(12,0) // IRR (Rial)
+  currency        String        @default("IRR")
+  status          PaymentStatus @default(PENDING)
+  transactionId   String?
+  idempotencyKey  String?
+
+  createdAt       DateTime      @default(now())
+  updatedAt       DateTime      @updatedAt
+  deleted_at      DateTime?
+
+  @@index([orderId])
+  @@index([status])
+}
+
+model Shipment {
+  id              String         @id @default(uuid())
+  orderId         String
+  order           Order          @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  carrier         String         @default("mock")
+  trackingNumber  String?
+  status          ShipmentStatus @default(PENDING)
+  cost            Decimal?       @db.Decimal(12,0) // IRR (Rial)
+  shippedAt       DateTime?
+  deliveredAt     DateTime?
+
+  createdAt       DateTime       @default(now())
+  updatedAt       DateTime       @updatedAt
+  deleted_at      DateTime?
+
+  @@index([orderId])
+  @@index([status])
+}

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -1,0 +1,52 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  // minimal seed: one category, one product, one variant, one image
+  const category = await prisma.category.upsert({
+    where: { slug: 'default' },
+    update: {},
+    create: { name: 'Default', slug: 'default' },
+  });
+
+  const product = await prisma.product.create({
+    data: {
+      title: 'Sample Product',
+      slug: 'sample-product',
+      categoryId: category.id,
+      published: true,
+      variants: {
+        create: [
+          {
+            sku: 'SP-001',
+            title: 'Default',
+            // IRR as string (Decimal(12,0) in DB)
+            price: '250000',
+            stock: 10
+          }
+        ]
+      },
+      images: {
+        create: [
+          {
+            url: 'https://example.com/sample.jpg',
+            alt: 'Sample',
+            position: 0
+          }
+        ]
+      }
+    }
+  });
+
+  console.log('Seeded:', { category: category.slug, product: product.slug });
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -1,0 +1,15 @@
+import { Module, MiddlewareConsumer } from '@nestjs/common';
+import { LoggerModule } from 'nestjs-pino';
+import { HealthController } from './health/health.controller.js';
+import { MetricsController } from './metrics/metrics.controller.js';
+import { CorrelationIdMiddleware } from './common/correlation-id.middleware.js';
+
+@Module({
+  imports: [LoggerModule.forRoot()],
+  controllers: [HealthController, MetricsController],
+})
+export class AppModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(CorrelationIdMiddleware).forRoutes('*');
+  }
+}

--- a/apps/backend/src/common/correlation-id.middleware.ts
+++ b/apps/backend/src/common/correlation-id.middleware.ts
@@ -1,0 +1,19 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { PinoLogger } from 'nestjs-pino';
+import { randomUUID } from 'node:crypto';
+import type { Request, Response, NextFunction } from 'express';
+
+@Injectable()
+export class CorrelationIdMiddleware implements NestMiddleware {
+  constructor(private readonly logger: PinoLogger) {}
+
+  use(req: Request, res: Response, next: NextFunction) {
+    const header = req.headers['x-request-id'];
+    const correlationId = Array.isArray(header) ? header[0] : header;
+    const id = correlationId ?? randomUUID();
+    req.id = id;
+    res.setHeader('x-request-id', id);
+    this.logger.assign({ correlationId: id });
+    next();
+  }
+}

--- a/apps/backend/src/health/health.controller.ts
+++ b/apps/backend/src/health/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class HealthController {
+  @Get('healthz')
+  getHealth() {
+    return { status: 'ok' };
+  }
+}

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,0 +1,26 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module.js';
+import { Logger } from 'nestjs-pino';
+import helmet from 'helmet';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { VersioningType } from '@nestjs/common';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule, { bufferLogs: true });
+  const logger = app.get(Logger);
+  app.useLogger(logger);
+
+  app.use(helmet());
+  // TODO: add rate limiting
+
+  app.setGlobalPrefix('api');
+  app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
+
+  const config = new DocumentBuilder().setTitle('sed-shop API').setVersion('1.0').build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api/docs', app, document);
+
+  await app.listen(process.env.PORT || 3000);
+}
+
+bootstrap();

--- a/apps/backend/src/metrics/metrics.controller.ts
+++ b/apps/backend/src/metrics/metrics.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { collectDefaultMetrics, register } from 'prom-client';
+
+collectDefaultMetrics();
+
+@Controller()
+export class MetricsController {
+  @Get('metrics')
+  async getMetrics(@Res() res: Response) {
+    res.setHeader('Content-Type', register.contentType);
+    res.end(await register.metrics());
+  }
+}

--- a/apps/backend/test/health.e2e-spec.ts
+++ b/apps/backend/test/health.e2e-spec.ts
@@ -1,0 +1,30 @@
+import { Test } from '@nestjs/testing';
+import { INestApplication, VersioningType } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('Health', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('/api/v1/healthz (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/api/v1/healthz')
+      .expect(200)
+      .expect({ status: 'ok' });
+  });
+});

--- a/apps/backend/testcontainers.json
+++ b/apps/backend/testcontainers.json
@@ -1,0 +1,3 @@
+{
+  "ryukDisabled": true
+}

--- a/apps/backend/tsconfig.build.json
+++ b/apps/backend/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "test", "**/*.spec.ts", "prisma/**"]
+}

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "test", "**/*.spec.ts"]
+}

--- a/apps/backend/tsconfig.prisma.json
+++ b/apps/backend/tsconfig.prisma.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "./dist-prisma"
+  },
+  "include": ["prisma/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- adjust backend tsconfigs for NodeNext and decorator metadata
- add prisma tsconfig and extend typecheck script
- use .js extensions for ESM imports and silence jest mapper lint warning
- run Prisma seed through tsx for ESM compatibility
- seed data uses string IRR values instead of Prisma.Decimal to avoid NodeNext type errors

## Testing
- `pnpm -w -F @sed-shop/backend typecheck` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6897ba6f00f08321aa9c889a9588355a