### PR TITLE
feat: scaffold frontend with Nuxt 3 + Pinia + Tailwind (RTL, IRR)

### DIFF
--- a/apps/frontend/.eslintrc.cjs
+++ b/apps/frontend/.eslintrc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  root: true,
+  parser: 'vue-eslint-parser',
+  parserOptions: { parser: '@typescript-eslint/parser', ecmaVersion: 'latest', sourceType: 'module', extraFileExtensions: ['.vue'] },
+  env: { browser: true, es2022: true, node: true },
+  extends: ['eslint:recommended','plugin:@typescript-eslint/recommended','plugin:vue/vue3-recommended','plugin:prettier/recommended'],
+  rules: { 'vue/multi-word-component-names': 'off', '@typescript-eslint/no-explicit-any': 'warn' },
+  ignorePatterns: ['.nuxt/','dist/','coverage/']
+}

--- a/apps/frontend/app.vue
+++ b/apps/frontend/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtLayout />
+</template>

--- a/apps/frontend/components/Navbar.vue
+++ b/apps/frontend/components/Navbar.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <nav class="p-4 bg-gray-100 mb-4">
+    <NuxtLink to="/" class="mr-4">خانه</NuxtLink>
+    <NuxtLink to="/products" class="mr-4">محصولات</NuxtLink>
+    <NuxtLink to="/cart">سبد خرید</NuxtLink>
+  </nav>
+</template>

--- a/apps/frontend/components/ProductCard.vue
+++ b/apps/frontend/components/ProductCard.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+import type { Product } from '@sed-shop/shared-schemas'
+
+const { product } = defineProps<{ product: Product }>()
+const { format } = useCurrency()
+</script>
+
+<template>
+  <NuxtLink :to="`/products/${product.slug}`" class="block border rounded p-4 hover:shadow">
+    <img v-if="product.imageUrl" :src="product.imageUrl" :alt="product.title" class="mb-2" />
+    <h3 class="font-bold mb-2">{{ product.title }}</h3>
+    <p>{{ format(product.priceRial) }}</p>
+  </NuxtLink>
+</template>

--- a/apps/frontend/composables/useCurrency.ts
+++ b/apps/frontend/composables/useCurrency.ts
@@ -1,0 +1,9 @@
+export const useCurrency = () => {
+  const formatter = new Intl.NumberFormat('fa-IR', {
+    currency: 'IRR',
+    style: 'currency',
+    maximumFractionDigits: 0
+  })
+  const format = (value: number) => formatter.format(value)
+  return { format }
+}

--- a/apps/frontend/layouts/default.vue
+++ b/apps/frontend/layouts/default.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+</script>
+
+<template>
+  <div>
+    <Navbar />
+    <NuxtPage />
+  </div>
+</template>

--- a/apps/frontend/nuxt.config.ts
+++ b/apps/frontend/nuxt.config.ts
@@ -1,0 +1,11 @@
+export default defineNuxtConfig({
+  ssr: true,
+  modules: ['@pinia/nuxt', '@nuxtjs/tailwindcss'],
+  runtimeConfig: {
+    public: { apiBase: process.env.NUXT_PUBLIC_API_BASE || 'http://localhost:3000/api' }
+  },
+  app: {
+    head: { htmlAttrs: { lang: 'fa', dir: 'rtl' }, titleTemplate: (t?: string) => (t ? `${t} | Sed Shop` : 'Sed Shop') }
+  },
+  typescript: { strict: true }
+})

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@sed-shop/frontend",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "start": "nuxt start",
+    "lint": "eslint . --ext .js,.cjs,.mjs,.ts,.tsx,.vue --no-error-on-unmatched-pattern --max-warnings=0",
+    "typecheck": "nuxt prepare && vue-tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "nuxt": "^3.12.0",
+    "@pinia/nuxt": "^0.5.1",
+    "pinia": "^2.1.7",
+    "@nuxtjs/tailwindcss": "^6.12.1",
+    "@sed-shop/shared-schemas": "workspace:*",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "typescript": "~5.4.5",
+    "vue-tsc": "^2.0.21",
+    "eslint": "^8.57.0",
+    "@typescript-eslint/eslint-plugin": "^7.13.1",
+    "@typescript-eslint/parser": "^7.13.1",
+    "eslint-plugin-vue": "^9.26.0",
+    "vite": "^5.4.0",
+    "@vitejs/plugin-vue": "^5.0.4"
+  }
+}

--- a/apps/frontend/pages/cart.vue
+++ b/apps/frontend/pages/cart.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>سبد خرید</div>
+</template>

--- a/apps/frontend/pages/index.vue
+++ b/apps/frontend/pages/index.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { useProductsStore } from '@/stores/products'
+
+const store = useProductsStore()
+await store.fetchProducts()
+</script>
+
+<template>
+  <div class="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+    <ProductCard v-for="p in store.items" :key="p.id" :product="p" />
+  </div>
+</template>

--- a/apps/frontend/pages/products/[slug].vue
+++ b/apps/frontend/pages/products/[slug].vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { useRoute } from 'vue-router'
+import { useProductsStore } from '@/stores/products'
+
+const route = useRoute()
+const store = useProductsStore()
+const product = await store.fetchProduct(route.params.slug as string)
+const { format } = useCurrency()
+</script>
+
+<template>
+  <div v-if="product">
+    <h1 class="text-2xl font-bold mb-4">{{ product.title }}</h1>
+    <img v-if="product.imageUrl" :src="product.imageUrl" :alt="product.title" class="mb-4" />
+    <p>{{ format(product.priceRial) }}</p>
+  </div>
+</template>

--- a/apps/frontend/pages/products/index.vue
+++ b/apps/frontend/pages/products/index.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { useProductsStore } from '@/stores/products'
+
+const store = useProductsStore()
+await store.fetchProducts()
+</script>
+
+<template>
+  <div class="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+    <ProductCard v-for="p in store.items" :key="p.id" :product="p" />
+  </div>
+</template>

--- a/apps/frontend/stores/products.ts
+++ b/apps/frontend/stores/products.ts
@@ -1,0 +1,24 @@
+import { defineStore } from 'pinia'
+import type { Product } from '@sed-shop/shared-schemas'
+
+interface State {
+  items: Product[]
+}
+
+export const useProductsStore = defineStore('products', {
+  state: (): State => ({
+    items: []
+  }),
+  actions: {
+    async fetchProducts() {
+      const config = useRuntimeConfig()
+      const data = await $fetch<Product[]>(`${config.public.apiBase}/products`)
+      this.items = data.map((p: any) => ({ ...p, priceRial: Number(p.priceRial ?? p.price ?? 0) }))
+    },
+    async fetchProduct(slug: string) {
+      const config = useRuntimeConfig()
+      const product = await $fetch<Product>(`${config.public.apiBase}/products/${slug}`)
+      return { ...product, priceRial: Number((product as any).priceRial ?? (product as any).price ?? 0) } as Product
+    }
+  }
+})

--- a/apps/frontend/tailwind.config.ts
+++ b/apps/frontend/tailwind.config.ts
@@ -1,0 +1,6 @@
+import type { Config } from 'tailwindcss'
+export default {
+  content: ['./components/**/*.{vue,ts}','./layouts/**/*.vue','./pages/**/*.vue','./app.vue'],
+  theme: { extend: {} },
+  plugins: [require('@tailwindcss/forms'), require('@tailwindcss/typography')]
+} satisfies Config

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./.nuxt/tsconfig.json",
+  "compilerOptions": {
+    "strict": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": { "@/*": ["./*"], "~/*": ["./*"] },
+    "noEmit": true,
+    "composite": false
+  },
+  "include": ["app.vue","app.config.ts","**/*.ts","**/*.vue","components/**/*.vue","layouts/**/*.vue","pages/**/*.vue","plugins/**/*.ts","composables/**/*.ts","stores/**/*.ts"],
+  "exclude": ["node_modules","dist",".nuxt","coverage","vitest.config.*","postcss.config.*","tailwind.config.*"]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "turbo run lint",
     "test": "turbo run test",
     "format": "prettier -w .",
-    "prepare": "husky" ,
+    "prepare": "husky",
     "lint:root": "eslint . --ext .js,.cjs,.mjs,.ts,.tsx,.vue --no-error-on-unmatched-pattern --max-warnings=0 --fix",
     "typecheck:root": "tsc -p tsconfig.base.json --noEmit",
     "db:migrate": "echo \"(will run prisma migrate from apps/backend later)\"",
@@ -39,5 +39,9 @@
   "engines": {
     "node": ">=20",
     "pnpm": ">=9"
+  },
+  "overrides": {
+    "vite": "^5.4.0",
+    "@vitejs/plugin-vue": "^5.0.0"
   }
 }

--- a/packages/shared-schemas/package.json
+++ b/packages/shared-schemas/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@sed-shop/shared-schemas",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "files": ["src"],
+  "dependencies": {
+    "zod": "^3.23.8"
+  }
+}

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -1,0 +1,1 @@
+export * from './product'

--- a/packages/shared-schemas/src/product.ts
+++ b/packages/shared-schemas/src/product.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+export const ProductSchema = z.object({
+  id: z.string(),
+  slug: z.string(),
+  title: z.string(),
+  priceRial: z.number().int().nonnegative(),
+  imageUrl: z.string().url().nullable().optional()
+})
+export type Product = z.infer<typeof ProductSchema>

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,11 +10,27 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
-      "@shared/*": ["packages/*"],
-      "@backend/*": ["apps/backend/src/*"],
-      "@frontend/*": ["apps/frontend/*"]
+      "@shared/*": [
+        "packages/*"
+      ],
+      "@backend/*": [
+        "apps/backend/src/*"
+      ],
+      "@frontend/*": [
+        "apps/frontend/*"
+      ],
+      "@sed-shop/shared-schemas": [
+        "packages/shared-schemas/src"
+      ]
     }
   },
-  "files": ["types/global.d.ts"],
-  "exclude": ["node_modules", "dist", "build", ".turbo"]
+  "files": [
+    "types/global.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "build",
+    ".turbo"
+  ]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -2,18 +2,31 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**", "build/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**",
+        "build/**"
+      ]
     },
     "dev": {
       "cache": false,
       "persistent": true
     },
-    "lint": {},
-    "typecheck": {},
+    "lint": {
+      "outputs": []
+    },
+    "typecheck": {
+      "outputs": []
+    },
     "test": {
-      "dependsOn": ["^build"],
-      "outputs": ["coverage/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "coverage/**"
+      ]
     },
     "format": {
       "cache": false


### PR DESCRIPTION
## Summary
- scaffold Nuxt 3 SSR frontend with Pinia store and TailwindCSS (RTL)
- add shared Product schema package
- configure repo for Vite 5 and workspace type paths

## Testing
- `pnpm install` *(fails: Proxy response (403) when HTTP Tunneling)*
- `pnpm -w lint` *(fails: Proxy response (403) when HTTP Tunneling)*
- `pnpm -w typecheck` *(fails: Proxy response (403) when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_6898d47a430883218865632c8948e2c7