### PR TITLE
feat(frontend): scaffold nuxt app with products and store

### DIFF
--- a/apps/frontend/.eslintrc.cjs
+++ b/apps/frontend/.eslintrc.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  env: { 'vue/setup-compiler-macros': true },
+  globals: {
+    useRoute: 'readonly',
+    useRuntimeConfig: 'readonly',
+    useFetch: 'readonly',
+  },
+  overrides: [
+    {
+      files: ['pages/**/*.vue', 'layouts/**/*.vue', 'app.vue'],
+      rules: { 'vue/multi-word-component-names': 'off' },
+    },
+  ],
+};

--- a/apps/frontend/app.vue
+++ b/apps/frontend/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
+</template>

--- a/apps/frontend/components/AppFooter.vue
+++ b/apps/frontend/components/AppFooter.vue
@@ -1,0 +1,3 @@
+<template>
+  <footer class="p-4 text-center text-sm text-gray-500">© 2024 SED Shop</footer>
+</template>

--- a/apps/frontend/components/AppNavbar.vue
+++ b/apps/frontend/components/AppNavbar.vue
@@ -1,0 +1,18 @@
+<template>
+  <nav class="bg-gray-100 p-4">
+    <ul class="flex flex-wrap gap-4">
+      <li><NuxtLink to="/">خانه</NuxtLink></li>
+      <li><NuxtLink to="/products">محصولات</NuxtLink></li>
+      <li v-for="c in productsStore.categories" :key="c.id">
+        <NuxtLink :to="`/products?category=${c.slug}`">{{ c.name }}</NuxtLink>
+      </li>
+      <li class="ml-auto"><NuxtLink to="/cart">سبد خرید</NuxtLink></li>
+    </ul>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import { useProductsStore } from '~/stores/products';
+const productsStore = useProductsStore();
+await productsStore.fetchCategories();
+</script>

--- a/apps/frontend/components/ProductCard.vue
+++ b/apps/frontend/components/ProductCard.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="border rounded p-4 flex flex-col h-full">
+    <!-- prettier-ignore -->
+    <img
+      v-if="product.images[0]"
+      :src="product.images[0].url"
+      :alt="product.title"
+      class="w-full h-48 object-cover"
+    >
+    <h3 class="mt-2 text-lg">{{ product.title }}</h3>
+    <p class="text-gray-600 mt-auto">{{ formatPrice(product.variants[0]?.price) }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Product } from '@sed-shop/shared-schemas';
+import { useCurrency } from '~/composables/useCurrency';
+
+defineProps<{ product: Product }>();
+const formatPrice = (price?: number) => (price ? useCurrency(price) : '');
+</script>

--- a/apps/frontend/composables/useCurrency.ts
+++ b/apps/frontend/composables/useCurrency.ts
@@ -1,0 +1,5 @@
+export const useCurrency = (amount: number) =>
+  new Intl.NumberFormat('fa-IR', {
+    style: 'currency',
+    currency: 'IRR',
+  }).format(amount);

--- a/apps/frontend/layouts/default.vue
+++ b/apps/frontend/layouts/default.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>
+    <AppNavbar />
+    <slot />
+    <AppFooter />
+  </div>
+</template>

--- a/apps/frontend/nuxt.config.ts
+++ b/apps/frontend/nuxt.config.ts
@@ -1,0 +1,16 @@
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/tailwindcss', '@pinia/nuxt'],
+  app: {
+    head: {
+      htmlAttrs: {
+        lang: 'fa',
+        dir: 'rtl'
+      }
+    }
+  },
+  runtimeConfig: {
+    public: {
+      apiBase: process.env.API_BASE || 'http://localhost:3000'
+    }
+  }
+});

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@sed-shop/frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "lint": "eslint . --ext .ts,.vue --max-warnings=0",
+    "typecheck": "nuxt prepare && vue-tsc --noEmit",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "nuxt": "^3.12.3",
+    "pinia": "^2.1.7",
+    "@pinia/nuxt": "^0.5.1",
+    "@nuxtjs/tailwindcss": "^6.10.1",
+    "@sed-shop/shared-schemas": "workspace:*"
+  },
+  "devDependencies": {
+    "vue-tsc": "^2.0.27",
+    "eslint-plugin-nuxt": "^4.0.0"
+  }
+}

--- a/apps/frontend/pages/cart.vue
+++ b/apps/frontend/pages/cart.vue
@@ -1,0 +1,3 @@
+<template>
+  <div class="p-4">سبد خرید در دست ساخت است.</div>
+</template>

--- a/apps/frontend/pages/index.vue
+++ b/apps/frontend/pages/index.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { useProductsStore } from '~/stores/products';
+const store = useProductsStore();
+await store.fetchProducts();
+</script>
+
+<template>
+  <div class="p-4 grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+    <ProductCard v-for="p in store.items" :key="p.id" :product="p" />
+  </div>
+</template>

--- a/apps/frontend/pages/products/[slug].vue
+++ b/apps/frontend/pages/products/[slug].vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import type { Product } from '@sed-shop/shared-schemas';
+import { useCurrency } from '~/composables/useCurrency';
+const route = useRoute();
+const config = useRuntimeConfig();
+const { data: product } = await useFetch<Product>(
+  `${config.public.apiBase}/products/${route.params.slug}`,
+);
+</script>
+
+<template>
+  <div v-if="product" class="p-4 space-y-4">
+    <h1 class="text-2xl">{{ product.title }}</h1>
+    <!-- prettier-ignore -->
+    <img
+        v-if="product.images[0]"
+        :src="product.images[0].url"
+        :alt="product.title"
+        class="w-full max-w-md object-cover"
+      >
+    <p>{{ product.description }}</p>
+    <p class="font-bold" v-if="product.variants[0]">
+      {{ useCurrency(product.variants[0].price) }}
+    </p>
+  </div>
+</template>

--- a/apps/frontend/pages/products/index.vue
+++ b/apps/frontend/pages/products/index.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+import { useProductsStore } from '~/stores/products';
+const store = useProductsStore();
+const route = useRoute();
+await store.fetchProducts(route.query.category as string | undefined);
+</script>
+
+<template>
+  <div class="p-4 grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+    <ProductCard v-for="p in store.items" :key="p.id" :product="p" />
+  </div>
+</template>

--- a/apps/frontend/stores/cart.ts
+++ b/apps/frontend/stores/cart.ts
@@ -1,0 +1,9 @@
+import { defineStore } from 'pinia';
+
+type CartLine = { productId: string; variantId: string; quantity: number };
+
+export const useCartStore = defineStore('cart', {
+  state: () => ({
+    items: [] as CartLine[],
+  }),
+});

--- a/apps/frontend/stores/products.ts
+++ b/apps/frontend/stores/products.ts
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia';
+import type { Product, Category } from '@sed-shop/shared-schemas';
+
+export const useProductsStore = defineStore('products', {
+  state: () => ({
+    items: [] as Product[],
+    categories: [] as Category[],
+    loading: false,
+  }),
+  actions: {
+    async fetchProducts(category?: string) {
+      this.loading = true;
+      const config = useRuntimeConfig();
+      const query = category ? `?category=${category}` : '';
+      const { data } = await useFetch<Product[]>(`${config.public.apiBase}/products${query}`);
+      this.items = data.value ?? [];
+      this.loading = false;
+    },
+    async fetchCategories() {
+      const config = useRuntimeConfig();
+      const { data } = await useFetch<Category[]>(`${config.public.apiBase}/categories`);
+      this.categories = data.value ?? [];
+    },
+  },
+});

--- a/apps/frontend/tailwind.config.ts
+++ b/apps/frontend/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss';
+
+export default <Config>{
+  content: [
+    './components/**/*.{vue,ts}',
+    './layouts/**/*.vue',
+    './pages/**/*.{vue,ts}',
+    './composables/**/*.{ts}',
+    './app.vue'
+  ]
+};

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["nuxt", "@pinia/nuxt"],
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"],
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.vue"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "turbo run lint",
     "test": "turbo run test",
     "format": "prettier -w .",
-    "prepare": "husky" ,
+    "prepare": "husky",
     "lint:root": "eslint . --ext .js,.cjs,.mjs,.ts,.tsx,.vue --no-error-on-unmatched-pattern --max-warnings=0 --fix",
     "typecheck:root": "tsc -p tsconfig.base.json --noEmit",
     "db:migrate": "echo \"(will run prisma migrate from apps/backend later)\"",
@@ -34,7 +34,8 @@
     "lint-staged": "^15.2.7",
     "prettier": "^3.3.3",
     "turbo": "^2.0.4",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "eslint-plugin-vue": "^9.27.0"
   },
   "engines": {
     "node": ">=20",

--- a/packages/shared-schemas/package.json
+++ b/packages/shared-schemas/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@sed-shop/shared-schemas",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "lint": "eslint . --ext .ts --max-warnings=0",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  }
+}

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+export const ImageSchema = z.object({
+  id: z.string(),
+  url: z.string().url(),
+});
+export type Image = z.infer<typeof ImageSchema>;
+
+export const ProductVariantSchema = z.object({
+  id: z.string(),
+  price: z.number(),
+});
+export type ProductVariant = z.infer<typeof ProductVariantSchema>;
+
+export const CategorySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().nullish(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type Category = z.infer<typeof CategorySchema>;
+
+export const ProductSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  slug: z.string(),
+  description: z.string().nullish(),
+  categoryId: z.string().nullish(),
+  published: z.boolean(),
+  variants: z.array(ProductVariantSchema).default([]),
+  images: z.array(ImageSchema).default([]),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  category: CategorySchema.nullish(),
+});
+export type Product = z.infer<typeof ProductSchema>;

--- a/packages/shared-schemas/tsconfig.json
+++ b/packages/shared-schemas/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add Nuxt-specific ESLint overrides and globals for auto-imported composables
- rename single-word Navbar/Footer to AppNavbar/AppFooter and adjust layout
- prevent self-closing img in product detail page to satisfy lint rule

## Testing
- `./node_modules/.bin/prettier apps/frontend --write`
- `pnpm -w -F @sed-shop/frontend format` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `./node_modules/.bin/eslint apps/frontend --ext .ts,.vue --max-warnings=0` *(fails: Environment key "vue/setup-compiler-macros" is unknown)*

------
https://chatgpt.com/codex/tasks/task_e_6898dd5f6aec8321b6bca703cfbbd3c1