### PR TITLE
feat(frontend): scaffold Nuxt 3 + Pinia + Tailwind (SSR, IRR), strict typing & lint

### DIFF
--- a/apps/frontend/.eslintrc.cjs
+++ b/apps/frontend/.eslintrc.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  root: false,
+  parser: '@typescript-eslint/parser',
+  parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+  plugins: ['vue', '@typescript-eslint'],
+  extends: ['plugin:vue/vue3-recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  rules: {
+    'vue/html-self-closing': ['error', { html: { void: 'never', normal: 'always', component: 'always' } }],
+    '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }]
+  },
+  overrides: [
+    {
+      files: ['pages/**/*.vue', 'layouts/**/*.vue', 'app.vue'],
+      rules: { 'vue/multi-word-component-names': 'off' }
+    }
+  ]
+}

--- a/apps/frontend/app.vue
+++ b/apps/frontend/app.vue
@@ -1,0 +1,3 @@
+<template><NuxtLayout><NuxtPage /></NuxtLayout></template>
+<script setup lang="ts"></script>
+<style>@import '@/assets/css/tailwind.css';</style>

--- a/apps/frontend/assets/css/tailwind.css
+++ b/apps/frontend/assets/css/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/frontend/components/AppFooter.vue
+++ b/apps/frontend/components/AppFooter.vue
@@ -1,0 +1,2 @@
+<template><footer class="border-t p-4 text-center">© SED Shop</footer></template>
+<script setup lang="ts"></script>

--- a/apps/frontend/components/AppNavbar.vue
+++ b/apps/frontend/components/AppNavbar.vue
@@ -1,0 +1,7 @@
+<template>
+  <nav class="border-b p-4 flex gap-4">
+    <NuxtLink to="/">خانه</NuxtLink>
+    <NuxtLink to="/products">محصولات</NuxtLink>
+  </nav>
+</template>
+<script setup lang="ts"></script>

--- a/apps/frontend/components/ProductCard.vue
+++ b/apps/frontend/components/ProductCard.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="border rounded p-4 flex flex-col h-full">
+    <img v-if="product.images?.[0]" :src="product.images[0].url" :alt="product.title" class="w-full h-48 object-cover">
+    <h3 class="mt-2 text-lg">{{ product.title }}</h3>
+    <p class="text-gray-600 mt-auto">{{ formatPrice(product.variants?.[0]?.price) }}</p>
+  </div>
+</template>
+<script setup lang="ts">
+import type { Product } from '~/stores/products'
+import { useCurrency } from '~/composables/useCurrency'
+const { product } = defineProps<{ product: Product }>()
+const formatPrice = (price?: number | string) => (price != null ? useCurrency(price) : '')
+</script>

--- a/apps/frontend/composables/useCurrency.ts
+++ b/apps/frontend/composables/useCurrency.ts
@@ -1,0 +1,4 @@
+export function useCurrency(amount: number | string | null | undefined) {
+  const n = typeof amount === 'string' ? Number(amount) : amount ?? 0
+  return new Intl.NumberFormat('fa-IR', { style: 'currency', currency: 'IRR', maximumFractionDigits: 0 }).format(n)
+}

--- a/apps/frontend/env.d.ts
+++ b/apps/frontend/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="nuxt" />

--- a/apps/frontend/layouts/default.vue
+++ b/apps/frontend/layouts/default.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>
+    <AppNavbar />
+    <main class="container mx-auto p-4"><slot /></main>
+    <AppFooter />
+  </div>
+</template>

--- a/apps/frontend/nuxt.config.ts
+++ b/apps/frontend/nuxt.config.ts
@@ -1,0 +1,11 @@
+export default defineNuxtConfig({
+  ssr: true,
+  modules: ['@pinia/nuxt', '@nuxtjs/tailwindcss'],
+  typescript: { strict: true, shim: false },
+  runtimeConfig: {
+    public: {
+      apiBase: process.env.PUBLIC_API_BASE || 'http://localhost:3000/api'
+    }
+  },
+  app: { head: { titleTemplate: (title?: string) => (title ? `${title} · SED Shop` : 'SED Shop') } }
+})

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@sed-shop/frontend",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "start": "nuxt start",
+    "lint": "eslint . --ext .ts,.vue",
+    "typecheck": "nuxt prepare && vue-tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "nuxt": "^3.12.0",
+    "pinia": "^2.1.7",
+    "@pinia/nuxt": "^0.5.1",
+    "@nuxtjs/tailwindcss": "^6.10.5"
+  },
+  "devDependencies": {
+    "vue-tsc": "^2.0.28",
+    "tailwindcss": "^3.4.9",
+    "@tailwindcss/forms": "^0.5.7",
+    "@tailwindcss/typography": "^0.5.15",
+    "eslint": "^8.57.0",
+    "eslint-plugin-vue": "^9.25.0",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/apps/frontend/pages/index.vue
+++ b/apps/frontend/pages/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    <ProductCard v-for="p in store.products" :key="p.id" :product="p" />
+  </div>
+</template>
+<script setup lang="ts">
+import { useProductsStore } from '~/stores/products'
+import ProductCard from '~/components/ProductCard.vue'
+const store = useProductsStore()
+await store.fetchAll()
+</script>

--- a/apps/frontend/pages/products/[slug].vue
+++ b/apps/frontend/pages/products/[slug].vue
@@ -1,0 +1,17 @@
+<template>
+  <article class="prose max-w-none">
+    <h1>{{ product?.title }}</h1>
+    <img v-if="product?.images?.[0]" :src="product.images[0].url" :alt="product.title" class="w-full h-64 object-cover">
+    <p v-if="product?.variants?.[0]">{{ formatPrice(product.variants[0].price) }}</p>
+  </article>
+</template>
+<script setup lang="ts">
+import { useRoute } from '#imports'
+import { useProductsStore, type Product } from '~/stores/products'
+import { useCurrency } from '~/composables/useCurrency'
+const route = useRoute()
+const store = useProductsStore()
+const formatPrice = (p?: number | string) => (p != null ? useCurrency(p) : '')
+const slug = String(route.params.slug)
+const product = await store.fetchBySlug(slug) as Product
+</script>

--- a/apps/frontend/pages/products/index.vue
+++ b/apps/frontend/pages/products/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    <ProductCard v-for="p in store.products" :key="p.id" :product="p" />
+  </div>
+</template>
+<script setup lang="ts">
+import { useProductsStore } from '~/stores/products'
+import ProductCard from '~/components/ProductCard.vue'
+const store = useProductsStore()
+await store.fetchAll()
+</script>

--- a/apps/frontend/stores/products.ts
+++ b/apps/frontend/stores/products.ts
@@ -1,0 +1,28 @@
+import { defineStore } from 'pinia'
+import { useRuntimeConfig, useFetch } from '#imports'
+
+export type ProductImage = { url: string; alt?: string | null }
+export type ProductVariant = { price: number | string; title?: string | null }
+export type Product = { id: string; slug: string; title: string; images?: ProductImage[]; variants?: ProductVariant[] }
+
+export const useProductsStore = defineStore('products', {
+  state: () => ({ products: [] as Product[], bySlug: new Map<string, Product>() }),
+  actions: {
+    async fetchAll() {
+      const { public: { apiBase } } = useRuntimeConfig()
+      const { data, error } = await useFetch<Product[]>(`${apiBase}/products`)
+      if (error.value) throw error.value
+      this.products = data.value ?? []
+      this.products.forEach(p => this.bySlug.set(p.slug, p))
+    },
+    async fetchBySlug(slug: string) {
+      if (this.bySlug.has(slug)) return this.bySlug.get(slug)!
+      const { public: { apiBase } } = useRuntimeConfig()
+      const { data, error } = await useFetch<Product>(`${apiBase}/products/${slug}`)
+      if (error.value) throw error.value
+      const p = data.value!
+      this.bySlug.set(slug, p)
+      return p
+    }
+  }
+})

--- a/apps/frontend/tailwind.config.ts
+++ b/apps/frontend/tailwind.config.ts
@@ -1,0 +1,6 @@
+import type { Config } from 'tailwindcss'
+export default {
+  content: ['./components/**/*.{vue,ts}', './pages/**/*.{vue,ts}', './layouts/**/*.vue', './app.vue'],
+  theme: { extend: {} },
+  plugins: [require('@tailwindcss/forms'), require('@tailwindcss/typography')]
+} satisfies Config

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./.nuxt/tsconfig.json",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": ".",
+    "paths": { "~/*": ["./*"], "@/*": ["./*"] }
+  },
+  "include": ["**/*.ts", "**/*.vue", "nuxt.config.ts", ".nuxt/nuxt.d.ts", "env.d.ts"],
+  "exclude": ["vitest.config.ts"]
+}


### PR DESCRIPTION
## Summary
- scaffold Nuxt 3 SSR frontend with Pinia and Tailwind
- add currency composable for IRR formatting and typed products store
- implement product listing and detail pages with basic layout and components

## Testing
- `pnpm -w --filter @sed-shop/frontend install` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm -w turbo run lint typecheck` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_689990e19e6c83218bd0c7455d6fe8b4