### PR TITLE
feat(frontend): scaffold Nuxt 3 + Pinia + Tailwind (SSR, IRR), strict typing & lint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,18 +1,70 @@
 module.exports = {
   root: true,
-  env: {
-    node: true,
-    es2022: true,
-  },
   parser: '@typescript-eslint/parser',
   parserOptions: {
+    ecmaVersion: 'latest',
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint', 'prettier'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended',
+    'prettier',
   ],
-  ignorePatterns: ['dist', 'node_modules'],
+  plugins: ['@typescript-eslint'],
+  rules: {
+    // keep root rules minimal
+  },
+  overrides: [
+    {
+      files: ['**/*.vue'],
+      parser: 'vue-eslint-parser',
+      parserOptions: {
+        parser: '@typescript-eslint/parser',
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        extraFileExtensions: ['.vue'],
+      },
+      extends: [
+        'plugin:vue/vue3-recommended',
+        'plugin:@typescript-eslint/recommended',
+        'prettier',
+      ],
+      plugins: ['vue', '@typescript-eslint'],
+      rules: {
+        // don’t self-close HTML void elements like <img>
+        'vue/html-self-closing': ['error', {
+          html: { void: 'never', normal: 'never', component: 'always' },
+          svg: 'always',
+          math: 'always',
+        }],
+      },
+    },
+    {
+      // allow single-word component names only for Nuxt special files
+      files: ['apps/frontend/pages/**/*.vue', 'apps/frontend/layouts/**/*.vue', 'apps/frontend/app.vue'],
+      rules: { 'vue/multi-word-component-names': 'off' },
+    },
+    {
+      files: [
+        '*.cjs',
+        '*.config.cjs',
+        '.*rc.cjs',
+        '.eslintrc.cjs',
+        'commitlint.config.cjs',
+        'apps/**/.eslintrc.cjs',
+        'apps/**/vite.config.{ts,js,cjs,mjs}',
+        'apps/**/tailwind.config.{ts,js,cjs,mjs}',
+      ],
+      env: { node: true, browser: false },
+      // CJS config files are plain scripts, not ESM
+      parser: 'espree',
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'script',
+      },
+      rules: {
+        // keep default rules; no special relax unless necessary
+      },
+    },
+  ],
 };

--- a/apps/frontend/.eslintrc.cjs
+++ b/apps/frontend/.eslintrc.cjs
@@ -1,0 +1,31 @@
+module.exports = {
+  root: false,
+  parser: 'vue-eslint-parser',
+  parserOptions: {
+    parser: '@typescript-eslint/parser',
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    extraFileExtensions: ['.vue'],
+  },
+  extends: [
+    'plugin:vue/vue3-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+  ],
+  plugins: ['vue', '@typescript-eslint'],
+  rules: {
+    'vue/html-self-closing': ['error', {
+      html: { void: 'never', normal: 'never', component: 'always' },
+      svg: 'always',
+      math: 'always',
+    }],
+    '@typescript-eslint/no-unused-vars': ['error'],
+    '@typescript-eslint/no-explicit-any': ['error'],
+  },
+  overrides: [
+    {
+      files: ['pages/**/*.vue', 'layouts/**/*.vue', 'app.vue'],
+      rules: { 'vue/multi-word-component-names': 'off' },
+    },
+  ],
+}

--- a/apps/frontend/app.vue
+++ b/apps/frontend/app.vue
@@ -1,0 +1,3 @@
+<template><NuxtLayout><NuxtPage /></NuxtLayout></template>
+<script setup lang="ts"></script>
+<style>@import '@/assets/css/tailwind.css';</style>

--- a/apps/frontend/assets/css/tailwind.css
+++ b/apps/frontend/assets/css/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/frontend/components/AppFooter.vue
+++ b/apps/frontend/components/AppFooter.vue
@@ -1,0 +1,2 @@
+<template><footer class="border-t p-4 text-center">© SED Shop</footer></template>
+<script setup lang="ts"></script>

--- a/apps/frontend/components/AppNavbar.vue
+++ b/apps/frontend/components/AppNavbar.vue
@@ -1,0 +1,7 @@
+<template>
+  <nav class="border-b p-4 flex gap-4">
+    <NuxtLink to="/">خانه</NuxtLink>
+    <NuxtLink to="/products">محصولات</NuxtLink>
+  </nav>
+</template>
+<script setup lang="ts"></script>

--- a/apps/frontend/components/ProductCard.vue
+++ b/apps/frontend/components/ProductCard.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="border rounded p-4 flex flex-col h-full">
+    <img v-if="product.images?.[0]" :src="product.images[0].url" :alt="product.title" class="w-full h-48 object-cover">
+    <h3 class="mt-2 text-lg">{{ product.title }}</h3>
+    <p class="text-gray-600 mt-auto">{{ formatPrice(product.variants?.[0]?.price) }}</p>
+  </div>
+</template>
+<script setup lang="ts">
+import type { Product } from '@sed-shop/shared-schemas'
+import { useCurrency } from '~/composables/useCurrency'
+
+const { product } = defineProps<{ product: Product }>()
+
+const formatPrice = (price?: number | string) =>
+  price != null ? useCurrency(Number(price)) : ''
+</script>
+

--- a/apps/frontend/composables/useCurrency.ts
+++ b/apps/frontend/composables/useCurrency.ts
@@ -1,0 +1,4 @@
+export function useCurrency(amount: number | string | null | undefined) {
+  const n = typeof amount === 'string' ? Number(amount) : amount ?? 0
+  return new Intl.NumberFormat('fa-IR', { style: 'currency', currency: 'IRR', maximumFractionDigits: 0 }).format(n)
+}

--- a/apps/frontend/env.d.ts
+++ b/apps/frontend/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="nuxt" />

--- a/apps/frontend/layouts/default.vue
+++ b/apps/frontend/layouts/default.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>
+    <AppNavbar />
+    <main class="container mx-auto p-4"><slot /></main>
+    <AppFooter />
+  </div>
+</template>

--- a/apps/frontend/nuxt.config.ts
+++ b/apps/frontend/nuxt.config.ts
@@ -1,0 +1,11 @@
+export default defineNuxtConfig({
+  ssr: true,
+  modules: ['@pinia/nuxt', '@nuxtjs/tailwindcss'],
+  typescript: { strict: true, shim: false },
+  runtimeConfig: {
+    public: {
+      apiBase: process.env.PUBLIC_API_BASE || 'http://localhost:3000/api'
+    }
+  },
+  app: { head: { titleTemplate: (title?: string) => (title ? `${title} · SED Shop` : 'SED Shop') } }
+})

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@sed-shop/frontend",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nuxt dev",
+    "build": "nuxt build",
+    "start": "nuxt start",
+    "lint": "eslint . --ext .ts,.vue",
+    "typecheck": "nuxt prepare && vue-tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "nuxt": "^3.12.0",
+    "pinia": "^2.1.7",
+    "@pinia/nuxt": "^0.5.1",
+    "@nuxtjs/tailwindcss": "^6.10.5"
+  },
+  "devDependencies": {
+    "vue-tsc": "^2.0.28",
+    "tailwindcss": "^3.4.9",
+    "@tailwindcss/forms": "^0.5.7",
+    "@tailwindcss/typography": "^0.5.15",
+    "eslint": "^8.57.0",
+    "eslint-plugin-vue": "^9.25.0",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "vue-eslint-parser": "^9.4.2",
+    "typescript": "^5.4.0"
+  }
+}

--- a/apps/frontend/pages/index.vue
+++ b/apps/frontend/pages/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    <ProductCard v-for="p in store.products" :key="p.id" :product="p" />
+  </div>
+</template>
+<script setup lang="ts">
+import { useProductsStore } from '~/stores/products'
+import ProductCard from '~/components/ProductCard.vue'
+const store = useProductsStore()
+await store.fetchAll()
+</script>

--- a/apps/frontend/pages/products/[slug].vue
+++ b/apps/frontend/pages/products/[slug].vue
@@ -1,0 +1,24 @@
+<template>
+  <article class="prose max-w-none">
+    <h1>{{ product?.title }}</h1>
+    <img v-if="product?.images?.[0]" :src="product.images[0].url" :alt="product.title" class="w-full h-64 object-cover">
+    <p v-if="product?.variants?.[0]">{{ formatPrice(product.variants[0].price) }}</p>
+  </article>
+</template>
+<script setup lang="ts">
+import { useRoute, useRuntimeConfig, useFetch } from '#imports'
+import type { Product } from '@sed-shop/shared-schemas'
+import { useCurrency } from '~/composables/useCurrency'
+
+const route = useRoute()
+const {
+  public: { apiBase }
+} = useRuntimeConfig()
+
+const { data: product } = await useFetch<Product>(
+  `${apiBase}/v1/products/${route.params.slug}`
+)
+
+const formatPrice = (p?: number | string) =>
+  p != null ? useCurrency(Number(p)) : ''
+</script>

--- a/apps/frontend/pages/products/index.vue
+++ b/apps/frontend/pages/products/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    <ProductCard v-for="p in store.products" :key="p.id" :product="p" />
+  </div>
+</template>
+<script setup lang="ts">
+import { useProductsStore } from '~/stores/products'
+import ProductCard from '~/components/ProductCard.vue'
+const store = useProductsStore()
+await store.fetchAll()
+</script>

--- a/apps/frontend/stores/products.ts
+++ b/apps/frontend/stores/products.ts
@@ -1,0 +1,23 @@
+import type { Product } from '@sed-shop/shared-schemas'
+import { defineStore } from 'pinia'
+import { useRuntimeConfig, useFetch } from '#imports'
+
+export const useProductsStore = defineStore('products', {
+  state: () => ({
+    products: [] as Product[],
+    loading: false as boolean
+  }),
+  actions: {
+    async fetchAll() {
+      if (this.loading) return
+      this.loading = true
+      const {
+        public: { apiBase }
+      } = useRuntimeConfig()
+      const { data } = await useFetch<Product[]>(`${apiBase}/v1/products`)
+      this.products = data.value ?? []
+      this.loading = false
+    }
+  }
+})
+

--- a/apps/frontend/tailwind.config.ts
+++ b/apps/frontend/tailwind.config.ts
@@ -1,0 +1,6 @@
+import type { Config } from 'tailwindcss'
+export default {
+  content: ['./components/**/*.{vue,ts}', './pages/**/*.{vue,ts}', './layouts/**/*.vue', './app.vue'],
+  theme: { extend: {} },
+  plugins: [require('@tailwindcss/forms'), require('@tailwindcss/typography')]
+} satisfies Config

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./.nuxt/tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "strict": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.vue",
+    "types/**/*.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".nuxt/dist",
+    ".output",
+    "dist"
+  ]
+}

--- a/apps/frontend/types/shared-schemas.d.ts
+++ b/apps/frontend/types/shared-schemas.d.ts
@@ -1,0 +1,20 @@
+declare module '@sed-shop/shared-schemas' {
+  export interface ProductImage {
+    url: string
+    alt?: string | null
+  }
+
+  export interface ProductVariant {
+    price: number | string
+    title?: string | null
+  }
+
+  export interface Product {
+    id: string
+    slug: string
+    title: string
+    images?: ProductImage[]
+    variants?: ProductVariant[]
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
+    "eslint-plugin-vue": "^9.25.0",
+    "vue-eslint-parser": "^9.4.2",
     "husky": "^9.1.5",
     "lint-staged": "^15.2.7",
     "prettier": "^3.3.3",


### PR DESCRIPTION
## Summary
- scaffold Nuxt 3 SSR frontend with Pinia and Tailwind
- add currency composable for IRR formatting and typed products store
- implement product listing and detail pages with basic layout and components
- fix ESLint configs to parse Vue SFCs with vue-eslint-parser and add necessary dependencies
- treat CommonJS config files as Node scripts so ESLint recognizes module/require
- wire frontend typechecking through Nuxt's generated tsconfig, use shared Product types, and explicitly import Nuxt composables

## Testing
- `pnpm -w --filter @sed-shop/frontend install` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm -w turbo run lint typecheck` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm -w -F @sed-shop/frontend typecheck` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_689990e19e6c83218bd0c7455d6fe8b4