### PR TITLE
feat: add product and category modules

### DIFF
--- a/apps/backend/openapi.json
+++ b/apps/backend/openapi.json
@@ -23,6 +23,208 @@
           }
         }
       }
+    },
+    "/api/v1/products": {
+      "get": {
+        "summary": "List products",
+        "tags": ["products"],
+        "parameters": [
+          { "name": "q", "in": "query", "schema": { "type": "string" }, "required": false },
+          { "name": "category", "in": "query", "schema": { "type": "string" }, "required": false },
+          { "name": "minPrice", "in": "query", "schema": { "type": "integer" }, "required": false },
+          { "name": "maxPrice", "in": "query", "schema": { "type": "integer" }, "required": false },
+          { "name": "sort", "in": "query", "schema": { "type": "string" }, "required": false },
+          { "name": "page", "in": "query", "schema": { "type": "integer" }, "required": false },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" }, "required": false }
+        ],
+        "responses": {
+          "200": {
+            "description": "Product list",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ProductListResponse" }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create product",
+        "tags": ["products"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ProductPublic" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ProductPublic" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/products/{slug}": {
+      "get": {
+        "summary": "Get product by slug",
+        "tags": ["products"],
+        "parameters": [
+          { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Product detail",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ProductPublic" }
+              }
+            }
+          },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/api/v1/products/{id}": {
+      "patch": {
+        "summary": "Update product",
+        "tags": ["products"],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ProductPublic" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ProductPublic" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete product",
+        "tags": ["products"],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } }
+        ],
+        "responses": {
+          "200": { "description": "Deleted" }
+        }
+      }
+    },
+    "/api/v1/categories": {
+      "get": {
+        "summary": "List categories",
+        "tags": ["categories"],
+        "responses": {
+          "200": {
+            "description": "Category list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/CategoryPublic" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create category",
+        "tags": ["categories"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CategoryPublic" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CategoryPublic" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/categories/{slug}": {
+      "get": {
+        "summary": "Get category by slug",
+        "tags": ["categories"],
+        "parameters": [
+          { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Category detail",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CategoryPublic" }
+              }
+            }
+          },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/api/v1/categories/{id}": {
+      "patch": {
+        "summary": "Update category",
+        "tags": ["categories"],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CategoryPublic" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CategoryPublic" }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete category",
+        "tags": ["categories"],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string", "format": "uuid" } }
+        ],
+        "responses": {
+          "200": { "description": "Deleted" }
+        }
+      }
     }
   },
   "components": {
@@ -35,7 +237,75 @@
           "locale": { "type": "string", "example": "fa-IR" },
           "version": { "type": "string", "example": "v1" }
         }
+      },
+      "CategoryPublic": {
+        "type": "object",
+        "required": ["id", "name", "slug"],
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "parentId": { "type": "string", "format": "uuid", "nullable": true }
+        }
+      },
+      "ProductImagePublic": {
+        "type": "object",
+        "required": ["url"],
+        "properties": {
+          "url": { "type": "string" },
+          "alt": { "type": "string", "nullable": true },
+          "position": { "type": "integer", "nullable": true }
+        }
+      },
+      "ProductVariantPublic": {
+        "type": "object",
+        "required": ["id", "price", "stock"],
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "sku": { "type": "string", "nullable": true },
+          "price": { "type": "integer" },
+          "compareAtPrice": { "type": "integer", "nullable": true },
+          "stock": { "type": "integer" }
+        }
+      },
+      "ProductPublic": {
+        "type": "object",
+        "required": ["id", "title", "slug"],
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "title": { "type": "string" },
+          "slug": { "type": "string" },
+          "description": { "type": "string", "nullable": true },
+          "published": { "type": "boolean" },
+          "category": { "$ref": "#/components/schemas/CategoryPublic", "nullable": true },
+          "images": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ProductImagePublic" },
+            "nullable": true
+          },
+          "variants": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ProductVariantPublic" },
+            "nullable": true
+          },
+          "minPrice": { "type": "integer", "nullable": true },
+          "maxPrice": { "type": "integer", "nullable": true }
+        }
+      },
+      "ProductListResponse": {
+        "type": "object",
+        "required": ["items", "total", "page", "limit"],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ProductPublic" }
+          },
+          "total": { "type": "integer" },
+          "page": { "type": "integer" },
+          "limit": { "type": "integer" }
+        }
       }
     }
   }
 }
+

--- a/apps/backend/prisma/migrations/001_t4_products_categories/migration.sql
+++ b/apps/backend/prisma/migrations/001_t4_products_categories/migration.sql
@@ -1,0 +1,13 @@
+-- Migration for T4 products & categories
+-- Renames and schema adjustments
+
+ALTER TABLE "Category" RENAME COLUMN "deleted_at" TO "deletedAt";
+ALTER TABLE "Product" RENAME COLUMN "deleted_at" TO "deletedAt";
+ALTER TABLE "ProductVariant" RENAME COLUMN "deleted_at" TO "deletedAt";
+ALTER TABLE "Image" RENAME COLUMN "deleted_at" TO "deletedAt";
+
+ALTER TABLE "Image" RENAME TO "ProductImage";
+
+ALTER TABLE "ProductVariant" RENAME COLUMN "attributes" TO "attrs";
+ALTER TABLE "ProductVariant" ALTER COLUMN "price" TYPE INTEGER USING ("price"::integer);
+ALTER TABLE "ProductVariant" ALTER COLUMN "compareAtPrice" TYPE INTEGER USING ("compareAtPrice"::integer);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -88,7 +88,7 @@ model Category {
 
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
-  deleted_at  DateTime?
+  deletedAt  DateTime?
 
   @@index([slug])
 }
@@ -103,11 +103,11 @@ model Product {
   published    Boolean          @default(true)
 
   variants     ProductVariant[]
-  images       Image[]
+  images       ProductImage[]
 
   createdAt    DateTime         @default(now())
   updatedAt    DateTime         @updatedAt
-  deleted_at   DateTime?
+  deletedAt   DateTime?
 
   @@index([categoryId])
   @@index([title])
@@ -119,19 +119,19 @@ model ProductVariant {
   product         Product  @relation(fields: [productId], references: [id], onDelete: Cascade)
   sku             String   @unique
   title           String?
-  price           Decimal  @db.Decimal(12,0) // IRR (Rial)
-  compareAtPrice  Decimal? @db.Decimal(12,0) // IRR (Rial)
+  price           Int      // IRR (Toman) as integer
+  compareAtPrice  Int?
   stock           Int      @default(0)
-  attributes      Json?
+  attrs           Json?
 
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
-  deleted_at      DateTime?
+  deletedAt      DateTime?
 
   @@index([productId])
 }
 
-model Image {
+model ProductImage {
   id        String   @id @default(uuid())
   productId String
   product   Product  @relation(fields: [productId], references: [id], onDelete: Cascade)
@@ -141,7 +141,7 @@ model Image {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
-  deleted_at DateTime?
+  deletedAt DateTime?
 
   @@index([productId])
 }

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -2,50 +2,132 @@ import { PrismaClient } from '@prisma/client';
 
 const prisma = new PrismaClient();
 
-async function main() {
-  // minimal seed: one category, one product, one variant, one image
-  const category = await prisma.category.upsert({
-    where: { slug: 'default' },
-    update: {},
-    create: { name: 'Default', slug: 'default' },
+async function upsertCategory(data: { name: string; slug: string; parentSlug?: string }) {
+  const parent = data.parentSlug
+    ? await prisma.category.findUnique({ where: { slug: data.parentSlug } })
+    : null;
+  return prisma.category.upsert({
+    where: { slug: data.slug },
+    update: { name: data.name, parentId: parent?.id },
+    create: { name: data.name, slug: data.slug, parentId: parent?.id },
   });
+}
 
-  const product = await prisma.product.create({
+async function createProduct(data: {
+  title: string;
+  slug: string;
+  categorySlug?: string;
+  description?: string;
+  variants: { sku: string; price: number; stock: number; compareAtPrice?: number }[];
+  images: { url: string; alt?: string; position?: number }[];
+}) {
+  const existing = await prisma.product.findUnique({ where: { slug: data.slug } });
+  if (existing) return existing;
+  const category = data.categorySlug
+    ? await prisma.category.findUnique({ where: { slug: data.categorySlug } })
+    : null;
+  return prisma.product.create({
     data: {
-      title: 'Sample Product',
-      slug: 'sample-product',
-      categoryId: category.id,
+      title: data.title,
+      slug: data.slug,
+      description: data.description,
+      categoryId: category?.id,
       published: true,
-      variants: {
-        create: [
-          {
-            sku: 'SP-001',
-            title: 'Default',
-            // IRR as string (Decimal(12,0) in DB)
-            price: '250000',
-            stock: 10
-          }
-        ]
-      },
-      images: {
-        create: [
-          {
-            url: 'https://example.com/sample.jpg',
-            alt: 'Sample',
-            position: 0
-          }
-        ]
-      }
-    }
+      variants: { create: data.variants },
+      images: { create: data.images },
+    },
   });
+}
 
-  console.log('Seeded:', { category: category.slug, product: product.slug });
+async function main() {
+  // categories
+  const categories = [
+    { name: 'Electronics', slug: 'electronics' },
+    { name: 'Laptops', slug: 'laptops', parentSlug: 'electronics' },
+    { name: 'Phones', slug: 'phones', parentSlug: 'electronics' },
+    { name: 'Home', slug: 'home' },
+    { name: 'Kitchen', slug: 'kitchen', parentSlug: 'home' },
+  ];
+  for (const c of categories) {
+    await upsertCategory(c);
+  }
+
+  const products = [
+    {
+      title: 'Laptop Pro',
+      slug: 'laptop-pro',
+      categorySlug: 'laptops',
+      variants: [
+        { sku: 'LTP-BASE', price: 70000000, stock: 5 },
+        { sku: 'LTP-UP', price: 90000000, stock: 2 },
+      ],
+      images: [{ url: 'https://picsum.photos/seed/laptop-pro/400/300', alt: 'Laptop Pro' }],
+    },
+    {
+      title: 'Laptop Air',
+      slug: 'laptop-air',
+      categorySlug: 'laptops',
+      variants: [
+        { sku: 'LTA-1', price: 60000000, stock: 7 },
+      ],
+      images: [{ url: 'https://picsum.photos/seed/laptop-air/400/300', alt: 'Laptop Air' }],
+    },
+    {
+      title: 'Smartphone X',
+      slug: 'smartphone-x',
+      categorySlug: 'phones',
+      variants: [
+        { sku: 'SPX-64', price: 30000000, stock: 20 },
+        { sku: 'SPX-128', price: 35000000, stock: 10 },
+      ],
+      images: [{ url: 'https://picsum.photos/seed/smartphone-x/400/300', alt: 'Smartphone X' }],
+    },
+    {
+      title: 'Smartphone Mini',
+      slug: 'smartphone-mini',
+      categorySlug: 'phones',
+      variants: [{ sku: 'SPM-1', price: 25000000, stock: 15 }],
+      images: [{ url: 'https://picsum.photos/seed/smartphone-mini/400/300', alt: 'Smartphone Mini' }],
+    },
+    {
+      title: 'Coffee Maker',
+      slug: 'coffee-maker',
+      categorySlug: 'kitchen',
+      variants: [{ sku: 'CM-1', price: 5000000, stock: 15 }],
+      images: [{ url: 'https://picsum.photos/seed/coffee-maker/400/300', alt: 'Coffee Maker' }],
+    },
+    {
+      title: 'Blender Basic',
+      slug: 'blender-basic',
+      categorySlug: 'kitchen',
+      variants: [{ sku: 'BLD-1', price: 4000000, stock: 15 }],
+      images: [{ url: 'https://picsum.photos/seed/blender-basic/400/300', alt: 'Blender Basic' }],
+    },
+    {
+      title: 'Vacuum Cleaner',
+      slug: 'vacuum-cleaner',
+      categorySlug: 'home',
+      variants: [{ sku: 'VC-1', price: 8000000, stock: 8 }],
+      images: [{ url: 'https://picsum.photos/seed/vacuum-cleaner/400/300', alt: 'Vacuum Cleaner' }],
+    },
+    {
+      title: 'Microwave Oven',
+      slug: 'microwave-oven',
+      categorySlug: 'kitchen',
+      variants: [{ sku: 'MW-1', price: 10000000, stock: 6 }],
+      images: [{ url: 'https://picsum.photos/seed/microwave-oven/400/300', alt: 'Microwave Oven' }],
+    },
+  ];
+
+  for (const p of products) {
+    await createProduct(p);
+  }
 }
 
 main()
   .catch((e) => {
     console.error(e);
-    process.exitCode = 1;
+    process.exit(1);
   })
   .finally(async () => {
     await prisma.$disconnect();

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -4,9 +4,11 @@ import { HealthController } from './health/health.controller.js';
 import { MetricsController } from './metrics/metrics.controller.js';
 import { PingController } from './ping/ping.controller.js';
 import { CorrelationIdMiddleware } from './common/correlation-id.middleware.js';
+import { ProductsModule } from './products/products.module.js';
+import { CategoriesModule } from './categories/categories.module.js';
 
 @Module({
-  imports: [LoggerModule.forRoot()],
+  imports: [LoggerModule.forRoot(), ProductsModule, CategoriesModule],
   controllers: [HealthController, MetricsController, PingController],
 })
 export class AppModule {

--- a/apps/backend/src/categories/categories.controller.ts
+++ b/apps/backend/src/categories/categories.controller.ts
@@ -1,0 +1,40 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { CategoriesService } from './categories.service.js';
+import { CreateCategoryDto, UpdateCategoryDto } from './categories.dto.js';
+
+@ApiTags('categories')
+@Controller({ path: 'v1/categories' })
+export class CategoriesController {
+  constructor(private service: CategoriesService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List categories' })
+  list() {
+    return this.service.list();
+  }
+
+  @Get(':slug')
+  @ApiOperation({ summary: 'Get category by slug' })
+  detail(@Param('slug') slug: string) {
+    return this.service.detail(slug);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create category' })
+  create(@Body() dto: CreateCategoryDto) {
+    return this.service.create(dto);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update category' })
+  update(@Param('id') id: string, @Body() dto: UpdateCategoryDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete category (soft)' })
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/apps/backend/src/categories/categories.dto.ts
+++ b/apps/backend/src/categories/categories.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateCategoryDto {
+  @ApiProperty()
+  name!: string;
+
+  @ApiPropertyOptional()
+  slug?: string;
+
+  @ApiPropertyOptional()
+  parentId?: string;
+}
+
+export class UpdateCategoryDto {
+  @ApiPropertyOptional()
+  name?: string;
+
+  @ApiPropertyOptional()
+  slug?: string;
+
+  @ApiPropertyOptional()
+  parentId?: string;
+}

--- a/apps/backend/src/categories/categories.module.ts
+++ b/apps/backend/src/categories/categories.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CategoriesController } from './categories.controller.js';
+import { CategoriesService } from './categories.service.js';
+import { PrismaService } from '../common/prisma.service.js';
+
+@Module({
+  controllers: [CategoriesController],
+  providers: [CategoriesService, PrismaService],
+})
+export class CategoriesModule {}

--- a/apps/backend/src/categories/categories.service.ts
+++ b/apps/backend/src/categories/categories.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import { PrismaService } from '../common/prisma.service.js';
+import { CreateCategoryDto, UpdateCategoryDto } from './categories.dto.js';
+
+function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-');
+}
+
+@Injectable()
+export class CategoriesService {
+  constructor(private prisma: PrismaService) {}
+
+  async list() {
+    return this.prisma.category.findMany({ where: { deletedAt: null } });
+  }
+
+  async detail(slug: string) {
+    const cat = await this.prisma.category.findFirst({
+      where: { slug, deletedAt: null },
+      include: { _count: { select: { children: true } } },
+    });
+    if (!cat) throw new HttpException({ code: 'NOT_FOUND', message: 'Category not found' }, HttpStatus.NOT_FOUND);
+    return { ...cat, childrenCount: cat._count.children };
+  }
+
+  private async generateSlug(base: string, excludeId?: string) {
+    let slug = slugify(base);
+    let i = 1;
+    while (
+      await this.prisma.category.findFirst({
+        where: { slug, NOT: excludeId ? { id: excludeId } : undefined },
+      })
+    ) {
+      i += 1;
+      slug = `${slugify(base)}-${i}`;
+    }
+    return slug;
+  }
+
+  async create(dto: CreateCategoryDto) {
+    const slug = await this.generateSlug(dto.slug ?? dto.name);
+    return this.prisma.category.create({
+      data: { name: dto.name, slug, parentId: dto.parentId },
+    });
+  }
+
+  async update(id: string, dto: UpdateCategoryDto) {
+    const data: any = { ...dto };
+    if (dto.slug || dto.name) {
+      const base = dto.slug ?? dto.name!;
+      data.slug = await this.generateSlug(base, id);
+    }
+    return this.prisma.category.update({ where: { id }, data });
+  }
+
+  async remove(id: string) {
+    return this.prisma.category.update({
+      where: { id },
+      data: { deletedAt: new Date() },
+    });
+  }
+}

--- a/apps/backend/src/common/prisma.service.ts
+++ b/apps/backend/src/common/prisma.service.ts
@@ -1,0 +1,16 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+}

--- a/apps/backend/src/products/products.controller.ts
+++ b/apps/backend/src/products/products.controller.ts
@@ -1,0 +1,51 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query } from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { ProductsService } from './products.service.js';
+import {
+  CreateProductDto,
+  ProductListQueryDto,
+  UpdateProductDto,
+} from './products.dto.js';
+
+@ApiTags('products')
+@Controller({ path: 'v1/products' })
+export class ProductsController {
+  constructor(private service: ProductsService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List products' })
+  @ApiQuery({ name: 'q', required: false })
+  @ApiQuery({ name: 'category', required: false })
+  @ApiQuery({ name: 'minPrice', required: false })
+  @ApiQuery({ name: 'maxPrice', required: false })
+  @ApiQuery({ name: 'sort', required: false })
+  @ApiQuery({ name: 'page', required: false })
+  @ApiQuery({ name: 'limit', required: false })
+  list(@Query() query: ProductListQueryDto) {
+    return this.service.list(query);
+  }
+
+  @Get(':slug')
+  @ApiOperation({ summary: 'Get product by slug' })
+  detail(@Param('slug') slug: string) {
+    return this.service.detail(slug);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create product' })
+  create(@Body() dto: CreateProductDto) {
+    return this.service.create(dto);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update product' })
+  update(@Param('id') id: string, @Body() dto: UpdateProductDto) {
+    return this.service.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete product (soft)' })
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
+}

--- a/apps/backend/src/products/products.dto.ts
+++ b/apps/backend/src/products/products.dto.ts
@@ -1,0 +1,80 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ProductListQueryDto {
+  @ApiPropertyOptional()
+  q?: string;
+
+  @ApiPropertyOptional({ description: 'Category slug' })
+  category?: string;
+
+  @ApiPropertyOptional()
+  minPrice?: number;
+
+  @ApiPropertyOptional()
+  maxPrice?: number;
+
+  @ApiPropertyOptional({ description: 'comma separated e.g. createdAt:desc,title:asc' })
+  sort?: string;
+
+  @ApiPropertyOptional({ default: 1 })
+  page?: number;
+
+  @ApiPropertyOptional({ default: 20 })
+  limit?: number;
+
+  @ApiPropertyOptional({ default: true })
+  published?: boolean;
+}
+
+export class ProductVariantInputDto {
+  @ApiPropertyOptional()
+  sku?: string;
+
+  @ApiProperty()
+  price!: number;
+
+  @ApiPropertyOptional()
+  compareAtPrice?: number;
+
+  @ApiPropertyOptional()
+  stock?: number;
+
+  @ApiPropertyOptional()
+  attrs?: Record<string, any>;
+}
+
+export class ProductImageInputDto {
+  @ApiProperty()
+  url!: string;
+
+  @ApiPropertyOptional()
+  alt?: string;
+
+  @ApiPropertyOptional()
+  position?: number;
+}
+
+export class CreateProductDto {
+  @ApiProperty()
+  title!: string;
+
+  @ApiPropertyOptional()
+  slug?: string;
+
+  @ApiPropertyOptional()
+  description?: string;
+
+  @ApiPropertyOptional()
+  published?: boolean;
+
+  @ApiPropertyOptional()
+  categoryId?: string;
+
+  @ApiPropertyOptional({ type: () => [ProductVariantInputDto] })
+  variants?: ProductVariantInputDto[];
+
+  @ApiPropertyOptional({ type: () => [ProductImageInputDto] })
+  images?: ProductImageInputDto[];
+}
+
+export class UpdateProductDto extends CreateProductDto {}

--- a/apps/backend/src/products/products.module.ts
+++ b/apps/backend/src/products/products.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ProductsController } from './products.controller.js';
+import { ProductsService } from './products.service.js';
+import { PrismaService } from '../common/prisma.service.js';
+
+@Module({
+  controllers: [ProductsController],
+  providers: [ProductsService, PrismaService],
+})
+export class ProductsModule {}

--- a/apps/backend/src/products/products.service.ts
+++ b/apps/backend/src/products/products.service.ts
@@ -1,0 +1,153 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { Prisma, Product } from '@prisma/client';
+import { PrismaService } from '../common/prisma.service.js';
+import {
+  CreateProductDto,
+  ProductListQueryDto,
+  UpdateProductDto,
+} from './products.dto.js';
+
+function slugify(str: string): string {
+  return str
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-');
+}
+
+@Injectable()
+export class ProductsService {
+  constructor(private prisma: PrismaService) {}
+
+  private async generateSlug(base: string, excludeId?: string) {
+    let slug = slugify(base);
+    let i = 1;
+    while (
+      await this.prisma.product.findFirst({
+        where: { slug, NOT: excludeId ? { id: excludeId } : undefined },
+      })
+    ) {
+      i += 1;
+      slug = `${slugify(base)}-${i}`;
+    }
+    return slug;
+  }
+
+  private parseSort(sort?: string): Prisma.ProductOrderByWithRelationInput[] {
+    if (!sort) return [{ createdAt: 'desc' }];
+    const parts = sort.split(',');
+    const orderBy: Prisma.ProductOrderByWithRelationInput[] = [];
+    for (const p of parts) {
+      const [field, dir] = p.split(':');
+      if (!['createdAt', 'title'].includes(field)) {
+        throw new HttpException(
+          { code: 'INVALID_SORT', message: `Cannot sort by ${field}` },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+      orderBy.push({ [field]: dir === 'desc' ? 'desc' : 'asc' } as any);
+    }
+    return orderBy;
+  }
+
+  async list(query: ProductListQueryDto) {
+    const page = query.page && query.page > 0 ? query.page : 1;
+    const limit = query.limit && query.limit > 0 ? Math.min(query.limit, 100) : 20;
+    const where: Prisma.ProductWhereInput = { deletedAt: null };
+    if (query.published !== undefined) where.published = query.published;
+    else where.published = true;
+    if (query.q) {
+      where.OR = [
+        { title: { contains: query.q, mode: 'insensitive' } },
+        { description: { contains: query.q, mode: 'insensitive' } },
+      ];
+    }
+    if (query.category) {
+      where.category = { slug: query.category };
+    }
+    if (query.minPrice != null || query.maxPrice != null) {
+      where.variants = {
+        some: {
+          deletedAt: null,
+          price: {
+            gte: query.minPrice ?? undefined,
+            lte: query.maxPrice ?? undefined,
+          },
+        },
+      };
+    }
+    const orderBy = this.parseSort(query.sort);
+    const [items, total] = await this.prisma.$transaction([
+      this.prisma.product.findMany({
+        where,
+        orderBy,
+        skip: (page - 1) * limit,
+        take: limit,
+        include: {
+          category: true,
+          images: { where: { deletedAt: null }, orderBy: { position: 'asc' } },
+          variants: { where: { deletedAt: null } },
+        },
+      }),
+      this.prisma.product.count({ where }),
+    ]);
+
+    const mapped = items.map((p) => {
+      const prices = p.variants.map((v) => v.price);
+      const minPrice = prices.length ? Math.min(...prices) : undefined;
+      const maxPrice = prices.length ? Math.max(...prices) : undefined;
+      return { ...p, minPrice, maxPrice };
+    });
+
+    return { items: mapped, total, page, limit };
+  }
+
+  async detail(slug: string) {
+    const product = await this.prisma.product.findFirst({
+      where: { slug, deletedAt: null },
+      include: {
+        category: true,
+        images: { where: { deletedAt: null }, orderBy: { position: 'asc' } },
+        variants: { where: { deletedAt: null } },
+      },
+    });
+    if (!product)
+      throw new HttpException({ code: 'NOT_FOUND', message: 'Product not found' }, HttpStatus.NOT_FOUND);
+    const prices = product.variants.map((v) => v.price);
+    const minPrice = prices.length ? Math.min(...prices) : undefined;
+    const maxPrice = prices.length ? Math.max(...prices) : undefined;
+    return { ...product, minPrice, maxPrice };
+  }
+
+  async create(dto: CreateProductDto) {
+    const slug = await this.generateSlug(dto.slug ?? dto.title);
+    return this.prisma.product.create({
+      data: {
+        title: dto.title,
+        slug,
+        description: dto.description,
+        published: dto.published ?? true,
+        categoryId: dto.categoryId ?? null,
+        variants: dto.variants ? { create: dto.variants } : undefined,
+        images: dto.images ? { create: dto.images } : undefined,
+      },
+      include: { variants: true, images: true, category: true },
+    });
+  }
+
+  async update(id: string, dto: UpdateProductDto) {
+    const data: any = { ...dto };
+    if (dto.slug || dto.title) {
+      const base = dto.slug ?? dto.title!;
+      data.slug = await this.generateSlug(base, id);
+    }
+    return this.prisma.product.update({
+      where: { id },
+      data,
+      include: { variants: true, images: true, category: true },
+    });
+  }
+
+  async remove(id: string) {
+    return this.prisma.product.update({ where: { id }, data: { deletedAt: new Date() } });
+  }
+}

--- a/apps/backend/test/products.e2e-spec.ts
+++ b/apps/backend/test/products.e2e-spec.ts
@@ -1,0 +1,54 @@
+import { Test } from '@nestjs/testing';
+import { INestApplication, VersioningType } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from '../src/app.module.js';
+import { PrismaService } from '../src/common/prisma.service.js';
+
+describe('Products', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.enableVersioning({ type: VersioningType.URI, defaultVersion: '1' });
+    await app.init();
+
+    prisma = app.get(PrismaService);
+    // minimal seed if not exists
+    await prisma.category.upsert({
+      where: { slug: 'test-cat' },
+      update: {},
+      create: { name: 'Test Cat', slug: 'test-cat' },
+    });
+    await prisma.product.upsert({
+      where: { slug: 'test-prod' },
+      update: {},
+      create: {
+        title: 'Test Prod',
+        slug: 'test-prod',
+        category: { connect: { slug: 'test-cat' } },
+        variants: { create: [{ sku: 'TP-1', price: 1000, stock: 1 }] },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /api/v1/products returns list', async () => {
+    const res = await request(app.getHttpServer()).get('/api/v1/products').expect(200);
+    expect(res.body.total).toBeGreaterThan(0);
+    expect(res.body.items[0].slug).toBeDefined();
+  });
+
+  it('GET /api/v1/products/:slug returns detail', async () => {
+    const res = await request(app.getHttpServer()).get('/api/v1/products/test-prod').expect(200);
+    expect(Array.isArray(res.body.variants)).toBe(true);
+  });
+});

--- a/apps/frontend/components/ProductCard.vue
+++ b/apps/frontend/components/ProductCard.vue
@@ -6,12 +6,12 @@
   </div>
 </template>
 <script setup lang="ts">
-import type { Product } from '@sed-shop/shared-schemas'
+import type { ProductPublicT } from '@sed-shop/shared-schemas'
 import { useCurrency } from '~/composables/useCurrency'
 
-const { product } = defineProps<{ product: Product }>()
+const { product } = defineProps<{ product: ProductPublicT }>()
 
-const formatPrice = (price?: number | string) =>
-  price != null ? useCurrency(Number(price)) : ''
+const formatPrice = (price?: number) =>
+  price != null ? useCurrency(price) : ''
 </script>
 

--- a/apps/frontend/pages/products/[slug].vue
+++ b/apps/frontend/pages/products/[slug].vue
@@ -27,7 +27,7 @@ const route = useRoute()
 const api = useApiClient()
 const { data: product } = await useAsyncData('product', () =>
   api
-    .GET('/api/v1/products/{slug}', {
+    .GET('/v1/products/{slug}', {
       params: { path: { slug: route.params.slug as string } },
     })
     .then((r) => r.data)

--- a/apps/frontend/pages/products/index.vue
+++ b/apps/frontend/pages/products/index.vue
@@ -1,11 +1,62 @@
 <template>
-  <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-    <ProductCard v-for="p in store.products" :key="p.id" :product="p" />
+  <div>
+    <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div
+        v-for="p in data?.items"
+        :key="p.id"
+        class="border rounded p-4 flex flex-col"
+      >
+        <img
+          v-if="p.images?.[0]"
+          :src="p.images[0].url"
+          :alt="p.title"
+          class="w-full h-48 object-cover"
+        />
+        <h3 class="mt-2 text-lg">
+          <NuxtLink :to="`/products/${p.slug}`">{{ p.title }}</NuxtLink>
+        </h3>
+        <p class="text-gray-600 mt-auto">
+          {{ formatPrice(p.minPrice) }}
+          <span v-if="p.maxPrice && p.maxPrice !== p.minPrice"
+            >- {{ formatPrice(p.maxPrice) }}</span
+          >
+        </p>
+      </div>
+    </div>
+    <div class="mt-4 flex gap-2">
+      <NuxtLink
+        v-if="page > 1"
+        :to="{ query: { ...route.query, page: page - 1 } }"
+        class="px-2 py-1 border rounded"
+        >Prev</NuxtLink
+      >
+      <NuxtLink
+        v-if="data && page * limit < data.total"
+        :to="{ query: { ...route.query, page: page + 1 } }"
+        class="px-2 py-1 border rounded"
+        >Next</NuxtLink
+      >
+    </div>
   </div>
 </template>
 <script setup lang="ts">
-import { useProductsStore } from '~/stores/products'
-import ProductCard from '~/components/ProductCard.vue'
-const store = useProductsStore()
-await store.fetchAll()
+import { useRoute, useAsyncData, computed } from '#imports'
+import { useApiClient } from '~/composables/useApiClient'
+import { useCurrency } from '~/composables/useCurrency'
+
+const route = useRoute()
+const api = useApiClient()
+const query = {
+  q: route.query.q as string | undefined,
+  category: route.query.category as string | undefined,
+  sort: route.query.sort as string | undefined,
+  page: route.query.page ? Number(route.query.page) : undefined,
+  limit: route.query.limit ? Number(route.query.limit) : undefined,
+}
+const { data } = await useAsyncData('products', () =>
+  api.GET('/api/v1/products', { params: { query } }).then((r) => r.data)
+)
+const page = computed(() => Number(route.query.page ?? 1))
+const limit = computed(() => Number(route.query.limit ?? 20))
+const formatPrice = (p?: number) => (p != null ? useCurrency(p) : '')
 </script>

--- a/apps/frontend/pages/products/index.vue
+++ b/apps/frontend/pages/products/index.vue
@@ -54,7 +54,7 @@ const query = {
   limit: route.query.limit ? Number(route.query.limit) : undefined,
 }
 const { data } = await useAsyncData('products', () =>
-  api.GET('/api/v1/products', { params: { query } }).then((r) => r.data)
+  api.GET('/v1/products', { params: { query } }).then((r) => r.data)
 )
 const page = computed(() => Number(route.query.page ?? 1))
 const limit = computed(() => Number(route.query.limit ?? 20))

--- a/packages/api-client/src/schema.d.ts
+++ b/packages/api-client/src/schema.d.ts
@@ -10,6 +10,128 @@ export interface paths {
       };
     };
   };
+  "/api/v1/products": {
+    get: {
+      responses: {
+        200: {
+          content: {
+            "application/json": components["schemas"]["ProductListResponse"];
+          };
+        };
+      };
+    };
+    post: {
+      requestBody: {
+        content: {
+          "application/json": components["schemas"]["ProductPublic"];
+        };
+      };
+      responses: {
+        201: {
+          content: {
+            "application/json": components["schemas"]["ProductPublic"];
+          };
+        };
+      };
+    };
+  };
+  "/api/v1/products/{slug}": {
+    get: {
+      parameters: {
+        path: { slug: string };
+      };
+      responses: {
+        200: {
+          content: {
+            "application/json": components["schemas"]["ProductPublic"];
+          };
+        };
+      };
+    };
+  };
+  "/api/v1/products/{id}": {
+    patch: {
+      parameters: { path: { id: string } };
+      requestBody: {
+        content: {
+          "application/json": components["schemas"]["ProductPublic"];
+        };
+      };
+      responses: {
+        200: {
+          content: {
+            "application/json": components["schemas"]["ProductPublic"];
+          };
+        };
+      };
+    };
+    delete: {
+      parameters: { path: { id: string } };
+      responses: {
+        200: unknown;
+      };
+    };
+  };
+  "/api/v1/categories": {
+    get: {
+      responses: {
+        200: {
+          content: {
+            "application/json": components["schemas"]["CategoryPublic"][];
+          };
+        };
+      };
+    };
+    post: {
+      requestBody: {
+        content: {
+          "application/json": components["schemas"]["CategoryPublic"];
+        };
+      };
+      responses: {
+        201: {
+          content: {
+            "application/json": components["schemas"]["CategoryPublic"];
+          };
+        };
+      };
+    };
+  };
+  "/api/v1/categories/{slug}": {
+    get: {
+      parameters: { path: { slug: string } };
+      responses: {
+        200: {
+          content: {
+            "application/json": components["schemas"]["CategoryPublic"];
+          };
+        };
+      };
+    };
+  };
+  "/api/v1/categories/{id}": {
+    patch: {
+      parameters: { path: { id: string } };
+      requestBody: {
+        content: {
+          "application/json": components["schemas"]["CategoryPublic"];
+        };
+      };
+      responses: {
+        200: {
+          content: {
+            "application/json": components["schemas"]["CategoryPublic"];
+          };
+        };
+      };
+    };
+    delete: {
+      parameters: { path: { id: string } };
+      responses: {
+        200: unknown;
+      };
+    };
+  };
 }
 
 export interface components {
@@ -19,8 +141,45 @@ export interface components {
       locale: string;
       version: string;
     };
+    CategoryPublic: {
+      id: string;
+      name: string;
+      slug: string;
+      parentId?: string | null;
+    };
+    ProductImagePublic: {
+      url: string;
+      alt?: string | null;
+      position?: number | null;
+    };
+    ProductVariantPublic: {
+      id: string;
+      sku?: string | null;
+      price: number;
+      compareAtPrice?: number | null;
+      stock: number;
+    };
+    ProductPublic: {
+      id: string;
+      title: string;
+      slug: string;
+      description?: string | null;
+      published: boolean;
+      category?: components["schemas"]["CategoryPublic"] | null;
+      images?: components["schemas"]["ProductImagePublic"][] | null;
+      variants?: components["schemas"]["ProductVariantPublic"][] | null;
+      minPrice?: number | null;
+      maxPrice?: number | null;
+    };
+    ProductListResponse: {
+      items: components["schemas"]["ProductPublic"][];
+      total: number;
+      page: number;
+      limit: number;
+    };
   };
 }
 
 export interface operations {}
-export interface external {} 
+export interface external {}
+

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -46,3 +46,39 @@ export type Product = z.infer<typeof ProductSchema>;
 export type ProductVariant = z.infer<typeof ProductVariantSchema>;
 export type ProductImage = z.infer<typeof ProductImageSchema>;
 
+// T4: public schemas for products & categories
+export const MoneyInt = z.number().int().min(0);
+
+export const ProductImagePublic = z.object({
+  url: z.string().url(),
+  alt: z.string().nullish(),
+  position: z.number().int().min(0).optional(),
+});
+export const ProductVariantPublic = z.object({
+  id: z.string().uuid(),
+  sku: z.string().nullish(),
+  price: MoneyInt,
+  compareAtPrice: z.number().int().min(0).nullish(),
+  stock: z.number().int(),
+});
+export const CategoryPublic = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  slug: z.string(),
+  parentId: z.string().uuid().nullish(),
+});
+export const ProductPublic = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  slug: z.string(),
+  description: z.string().nullish(),
+  published: z.boolean(),
+  category: CategoryPublic.nullish(),
+  images: z.array(ProductImagePublic).optional(),
+  variants: z.array(ProductVariantPublic).optional(),
+  minPrice: MoneyInt.optional(),
+  maxPrice: MoneyInt.optional(),
+});
+export type ProductPublicT = z.infer<typeof ProductPublic>;
+export type CategoryPublicT = z.infer<typeof CategoryPublic>;
+

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -9,5 +9,6 @@
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc -p tsconfig.build.json --noEmit"
   },
-  "devDependencies": { "typescript": "^5.5.4" }
+  "devDependencies": { "typescript": "^5.5.4" },
+  "dependencies": { "@sed-shop/shared-schemas": "workspace:*" }
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,3 +1,5 @@
+import type { ProductPublicT, CategoryPublicT } from '@sed-shop/shared-schemas';
+
 export type UUID = string;
 export type CurrencyCode = 'IRR';
 export const DEFAULT_CURRENCY: CurrencyCode = 'IRR';
@@ -31,4 +33,22 @@ export interface ApiError {
   message: string;
   details?: unknown;
 }
+
+// T4 product/category types
+
+export type ProductSortField = 'createdAt' | 'title';
+
+export interface ProductListQuery {
+  q?: string;
+  category?: string; // slug
+  minPrice?: number;
+  maxPrice?: number;
+  sort?: SortParam[];
+  page?: number;
+  limit?: number;
+  published?: boolean;
+}
+
+export type ProductListResponse = PaginatedResponse<ProductPublicT>;
+export type { ProductPublicT, CategoryPublicT } from '@sed-shop/shared-schemas';
 


### PR DESCRIPTION
## Summary
- add Prisma models and seed data for categories, products, variants, images
- implement product and category modules with CRUD endpoints
- extend shared schemas/types and frontend pages for product browsing

## Testing
- `pnpm --filter @sed-shop/backend prisma migrate dev -n "t4_products_categories"` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*
- `pnpm openapi:gen` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*
- `pnpm --filter @sed-shop/backend test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*


------
https://chatgpt.com/codex/tasks/task_e_689a14f2e48c8321817cea0276c1e542